### PR TITLE
Implemented AMQP reject when messages don't fit into the queue

### DIFF
--- a/acceptance/src/main/resources/application.conf
+++ b/acceptance/src/main/resources/application.conf
@@ -24,7 +24,8 @@ msbConfig {
     durable = false
     consumerThreadPoolSize = 5
     # -1 means unlimited
-    consumerThreadPoolQueueCapacity = -1
+    consumerThreadPoolQueueCapacity = 20
+    requeueRejectedMessages = true
   }
 
 }

--- a/amqp/src/main/java/io/github/tcdl/msb/adapters/amqp/AmqpConsumerAdapter.java
+++ b/amqp/src/main/java/io/github/tcdl/msb/adapters/amqp/AmqpConsumerAdapter.java
@@ -2,12 +2,11 @@ package io.github.tcdl.msb.adapters.amqp;
 
 import com.rabbitmq.client.Channel;
 import io.github.tcdl.msb.adapters.ConsumerAdapter;
-import io.github.tcdl.msb.config.amqp.AmqpBrokerConfig;
 import io.github.tcdl.msb.api.exception.ChannelException;
+import io.github.tcdl.msb.config.amqp.AmqpBrokerConfig;
 import org.apache.commons.lang3.Validate;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.concurrent.ExecutorService;
 
 public class AmqpConsumerAdapter implements ConsumerAdapter {
@@ -57,8 +56,7 @@ public class AmqpConsumerAdapter implements ConsumerAdapter {
             channel.queueDeclare(queueName, durable /* durable */, false /* exclusive */, !durable /*auto-delete */, null);
             channel.queueBind(queueName, exchangeName, "");
 
-            Charset charset = adapterConfig.getCharset();
-            consumerTag = channel.basicConsume(queueName, false /* autoAck */, new AmqpMessageConsumer(channel, consumerThreadPool, msgHandler, charset));
+            consumerTag = channel.basicConsume(queueName, false /* autoAck */, new AmqpMessageConsumer(channel, consumerThreadPool, msgHandler, adapterConfig));
         } catch (IOException e) {
             throw new ChannelException(String.format("Failed to subscribe to topic %s", topic), e);
         }

--- a/amqp/src/main/java/io/github/tcdl/msb/adapters/amqp/AmqpMessageConsumer.java
+++ b/amqp/src/main/java/io/github/tcdl/msb/adapters/amqp/AmqpMessageConsumer.java
@@ -5,6 +5,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import io.github.tcdl.msb.adapters.ConsumerAdapter;
+import io.github.tcdl.msb.config.amqp.AmqpBrokerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,22 +30,35 @@ public class AmqpMessageConsumer extends DefaultConsumer {
 
     ExecutorService consumerThreadPool;
     ConsumerAdapter.RawMessageHandler msgHandler;
-    private Charset charset;
+    private AmqpBrokerConfig amqpBrokerConfig;
 
-    public AmqpMessageConsumer(Channel channel, ExecutorService consumerThreadPool, ConsumerAdapter.RawMessageHandler msgHandler, Charset charset) {
+    public AmqpMessageConsumer(Channel channel, ExecutorService consumerThreadPool, ConsumerAdapter.RawMessageHandler msgHandler, AmqpBrokerConfig amqpBrokerConfig) {
         super(channel);
         this.consumerThreadPool = consumerThreadPool;
         this.msgHandler = msgHandler;
-        this.charset = charset;
+        this.amqpBrokerConfig = amqpBrokerConfig;
     }
 
     @Override
     public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
         try {
+            Charset charset = amqpBrokerConfig.getCharset();
+            boolean requeueRejectedMessages = amqpBrokerConfig.isRequeueRejectedMessages();
             String bodyStr = new String(body, charset);
             LOG.debug(String.format("[consumer tag: %s] Message consumed from broker: %s", consumerTag, bodyStr));
-            consumerThreadPool.submit(new AmqpMessageProcessingTask(consumerTag, bodyStr, getChannel(), envelope.getDeliveryTag(), msgHandler));
-            LOG.debug(String.format("[consumer tag: %s] Message has been put into processing pool: %s", consumerTag, bodyStr));
+            try {
+                consumerThreadPool.submit(new AmqpMessageProcessingTask(consumerTag, bodyStr, getChannel(), envelope.getDeliveryTag(), msgHandler));
+                LOG.debug(String.format("[consumer tag: %s] Message has been put in the processing queue: %s. About to send AMQP ack...",
+                        consumerTag, bodyStr));
+
+                getChannel().basicAck(envelope.getDeliveryTag(), false);
+                LOG.debug(String.format("[consumer tag: %s] AMQP ack has been sent for message '%s'", consumerTag, bodyStr));
+            } catch (Exception e) {
+                LOG.error(String.format("[consumer tag: %s] Couldn't put message in the processing queue: %s. About to send AMQP reject...",
+                        consumerTag, bodyStr), e);
+                getChannel().basicReject(envelope.getDeliveryTag(), requeueRejectedMessages);
+                LOG.error(String.format("[consumer tag: %s] AMQP reject has been sent for message: %s", consumerTag, bodyStr));
+            }
         } catch (Exception e) {
             // Catch all exceptions to prevent AMQP channel to be closed
             LOG.error(String.format("[consumer tag: %s] Got exception while processing incoming message", consumerTag), e);

--- a/amqp/src/main/java/io/github/tcdl/msb/adapters/amqp/AmqpMessageProcessingTask.java
+++ b/amqp/src/main/java/io/github/tcdl/msb/adapters/amqp/AmqpMessageProcessingTask.java
@@ -35,9 +35,7 @@ public class AmqpMessageProcessingTask implements Runnable {
         try {
             LOG.debug(String.format("[consumer tag: %s] Starting message processing: %s", consumerTag, body));
             msgHandler.onMessage(body);
-            LOG.debug(String.format("[consumer tag: %s] Message has been processed: %s. About to send AMQP ack...", consumerTag, body));
-            channel.basicAck(deliveryTag, false);
-            LOG.debug(String.format("[consumer tag: %s] AMQP ack has been sent for message '%s'", consumerTag, body));
+            LOG.debug(String.format("[consumer tag: %s] Message has been processed: %s", consumerTag, body));
         } catch (Exception e) {
             LOG.error(String.format("[consumer tag: %s] Failed to process message %s", consumerTag, body), e);
         }

--- a/amqp/src/main/java/io/github/tcdl/msb/config/amqp/AmqpBrokerConfig.java
+++ b/amqp/src/main/java/io/github/tcdl/msb/config/amqp/AmqpBrokerConfig.java
@@ -22,11 +22,11 @@ public class AmqpBrokerConfig {
     private final boolean durable;
     private final int consumerThreadPoolSize;
     private final int consumerThreadPoolQueueCapacity;
+    private final boolean requeueRejectedMessages;
 
     public AmqpBrokerConfig(Charset charset, String host, int port,
             Optional<String> username, Optional<String> password, Optional<String> virtualHost,
-            String groupId, boolean durable,
-            int consumerThreadPoolSize, int consumerThreadPoolQueueCapacity) {
+            String groupId, boolean durable, int consumerThreadPoolSize, int consumerThreadPoolQueueCapacity, boolean requeueRejectedMessages) {
         this.charset = charset;
         this.port = port;
         this.host = host;
@@ -37,6 +37,7 @@ public class AmqpBrokerConfig {
         this.durable = durable;
         this.consumerThreadPoolSize = consumerThreadPoolSize;
         this.consumerThreadPoolQueueCapacity = consumerThreadPoolQueueCapacity;
+        this.requeueRejectedMessages = requeueRejectedMessages;
     }
 
     public static class AmqpBrokerConfigBuilder {
@@ -50,6 +51,7 @@ public class AmqpBrokerConfig {
         private boolean durable;
         private int consumerThreadPoolSize;
         private int consumerThreadPoolQueueCapacity;
+        private boolean requeueRejectedMessages;
 
         /**
          * Initialize Builder with Config
@@ -75,6 +77,7 @@ public class AmqpBrokerConfig {
             this.durable = ConfigurationUtil.getBoolean(config, "durable");
             this.consumerThreadPoolSize = ConfigurationUtil.getInt(config, "consumerThreadPoolSize");
             this.consumerThreadPoolQueueCapacity = ConfigurationUtil.getInt(config, "consumerThreadPoolQueueCapacity");
+            this.requeueRejectedMessages = ConfigurationUtil.getBoolean(config, "requeueRejectedMessages");
             return this;
         }
 
@@ -83,7 +86,7 @@ public class AmqpBrokerConfig {
          */
         public AmqpBrokerConfig build() {
             return new AmqpBrokerConfig(charset, host, port, username, password, virtualHost,
-                    groupId, durable, consumerThreadPoolSize, consumerThreadPoolQueueCapacity);
+                    groupId, durable, consumerThreadPoolSize, consumerThreadPoolQueueCapacity, requeueRejectedMessages);
         }
     }
 
@@ -131,10 +134,14 @@ public class AmqpBrokerConfig {
         return consumerThreadPoolQueueCapacity;
     }
 
+    public boolean isRequeueRejectedMessages() {
+        return requeueRejectedMessages;
+    }
+
     @Override
     public String toString() {
-        return String.format("AmqpBrokerConfig [charset=%s, host=%s, port=%d, username=%s, password=xxx, virtualHost=%s, groupId=%s, durable=%s, consumerThreadPoolSize=%s, consumerThreadPoolQueueCapacity=%s]",
-                charset, host, port, username, virtualHost, groupId, durable, consumerThreadPoolSize, consumerThreadPoolQueueCapacity);
+        return String.format("AmqpBrokerConfig [charset=%s, host=%s, port=%d, username=%s, password=xxx, virtualHost=%s, groupId=%s, durable=%s, consumerThreadPoolSize=%s, consumerThreadPoolQueueCapacity=%s, requeueRejectedMessages=%s]",
+                charset, host, port, username, virtualHost, groupId, durable, consumerThreadPoolSize, consumerThreadPoolQueueCapacity, requeueRejectedMessages);
     }
 
 }

--- a/amqp/src/main/resources/amqp.conf
+++ b/amqp/src/main/resources/amqp.conf
@@ -15,5 +15,6 @@ config.amqp = {
   durable = false
   consumerThreadPoolSize = 5
   # -1 means unlimited
-  consumerThreadPoolQueueCapacity = -1
+  consumerThreadPoolQueueCapacity = 20
+  rejectedMessagesPolicy = true
 }

--- a/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpAdapterFactoryExecutorTest.java
+++ b/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpAdapterFactoryExecutorTest.java
@@ -46,6 +46,7 @@ public class AmqpAdapterFactoryExecutorTest {
                         + "    charsetName = \"UTF-8\"\n"
                         + "    consumerThreadPoolSize = 5\n"
                         + "    consumerThreadPoolQueueCapacity = 20\n"
+                        + "    requeueRejectedMessages = true\n"
                         + "  }";
 
         Config msbConfig = ConfigFactory.parseString(String.format(basicConfig, brokerConf));
@@ -72,6 +73,7 @@ public class AmqpAdapterFactoryExecutorTest {
                         + "    charsetName = \"UTF-8\"\n"
                         + "    consumerThreadPoolSize = 5\n"
                         + "    consumerThreadPoolQueueCapacity = -1\n"
+                        + "    requeueRejectedMessages = true\n"
                         + "  }";
         Config msbConfig = ConfigFactory.parseString(String.format(basicConfig, brokerConf));
         MsbConfig msbConfigurations = new MsbConfig(msbConfig);

--- a/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpAdapterFactoryTest.java
+++ b/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpAdapterFactoryTest.java
@@ -39,6 +39,7 @@ public class AmqpAdapterFactoryTest {
     final boolean durable = false;
     final int consumerThreadPoolSize = 5;
     final int consumerThreadPoolQueueCapacity = 20;
+    final boolean requeueRejectedMessages = true;
     
     AmqpBrokerConfig amqpConfig;
     AmqpAdapterFactory amqpAdapterFactory;
@@ -76,7 +77,7 @@ public class AmqpAdapterFactoryTest {
         }
         
         amqpConfig = new AmqpBrokerConfig(charset, host, port,
-                Optional.of(username), Optional.of(password), Optional.of(virtualHost), groupId, durable, consumerThreadPoolSize, consumerThreadPoolQueueCapacity);
+                Optional.of(username), Optional.of(password), Optional.of(virtualHost), groupId, durable, consumerThreadPoolSize, consumerThreadPoolQueueCapacity, requeueRejectedMessages);
         
         amqpAdapterFactory = new AmqpAdapterFactory() {
             @Override

--- a/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpConsumerAdapterTest.java
+++ b/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpConsumerAdapterTest.java
@@ -124,7 +124,7 @@ public class AmqpConsumerAdapterTest {
     }
 
     private AmqpConsumerAdapter createAdapter(String topic, String groupId, boolean durable) {
-        AmqpBrokerConfig nondurableAmqpConfig = new AmqpBrokerConfig(Charset.forName("UTF-8"), "127.0.0.1", 10, Optional.empty(), Optional.empty(), Optional.empty(), groupId, durable, 5, 20);
+        AmqpBrokerConfig nondurableAmqpConfig = new AmqpBrokerConfig(Charset.forName("UTF-8"), "127.0.0.1", 10, Optional.empty(), Optional.empty(), Optional.empty(), groupId, durable, 5, 20, true);
         return new AmqpConsumerAdapter(topic, nondurableAmqpConfig, mockAmqpConnectionManager, mockConsumerThreadPool);
     }
 }

--- a/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpMessageProcessingTaskTest.java
+++ b/amqp/src/test/java/io/github/tcdl/msb/adapters/amqp/AmqpMessageProcessingTaskTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class AmqpMessageProcessingTaskTest {
 
     private String messageStr = "some message";
-    private long deliveryTag = 123L;
 
     private Channel mockChannel;
     private ConsumerAdapter.RawMessageHandler mockMessageHandler;
@@ -28,7 +27,7 @@ public class AmqpMessageProcessingTaskTest {
     public void setUp() {
         mockChannel = mock(Channel.class);
         mockMessageHandler = mock(ConsumerAdapter.RawMessageHandler.class);
-        task = new AmqpMessageProcessingTask("consumer tag", messageStr, mockChannel, deliveryTag, mockMessageHandler);
+        task = new AmqpMessageProcessingTask("consumer tag", messageStr, mockChannel, 123L, mockMessageHandler);
     }
 
     @Test
@@ -36,7 +35,6 @@ public class AmqpMessageProcessingTaskTest {
         task.run();
 
         verify(mockMessageHandler).onMessage(messageStr);
-        verify(mockChannel).basicAck(deliveryTag, false);
     }
 
     @Test

--- a/amqp/src/test/java/io/github/tcdl/msb/config/amqp/AmqpBrokerConfigTest.java
+++ b/amqp/src/test/java/io/github/tcdl/msb/config/amqp/AmqpBrokerConfigTest.java
@@ -24,6 +24,7 @@ public class AmqpBrokerConfigTest {
     final boolean durable = false;
     final int consumerThreadPoolSize = 5;
     final int consumerThreadPoolQueueCapacity = 20;
+    final boolean requeueRejectedMessages = true;
 
     @Test
     public void testBuildAmqpBrokerConfig() {
@@ -38,6 +39,7 @@ public class AmqpBrokerConfigTest {
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         Config amqpConfig = ConfigFactory.parseString(configStr).getConfig("config.amqp");
@@ -51,6 +53,7 @@ public class AmqpBrokerConfigTest {
         assertEquals(brokerConfig.isDurable(), durable);
         assertEquals(brokerConfig.getConsumerThreadPoolSize(), consumerThreadPoolSize);
         assertEquals(brokerConfig.getConsumerThreadPoolQueueCapacity(), consumerThreadPoolQueueCapacity);
+        assertEquals(brokerConfig.isRequeueRejectedMessages(), requeueRejectedMessages);
 
         assertEquals(brokerConfig.getUsername().get(), username);
         assertEquals(brokerConfig.getPassword().get(), password);
@@ -67,6 +70,7 @@ public class AmqpBrokerConfigTest {
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         Config amqpConfig = ConfigFactory.parseString(configStr).getConfig("config.amqp");
@@ -92,6 +96,7 @@ public class AmqpBrokerConfigTest {
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "host");
@@ -109,6 +114,7 @@ public class AmqpBrokerConfigTest {
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "port");
@@ -126,6 +132,7 @@ public class AmqpBrokerConfigTest {
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "groupId");
@@ -143,6 +150,7 @@ public class AmqpBrokerConfigTest {
                 + " groupId = \"" + groupId + "\"\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "durable");
@@ -160,6 +168,7 @@ public class AmqpBrokerConfigTest {
                 + " groupId = \"" + groupId + "\"\n"
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "consumerThreadPoolSize");
@@ -177,6 +186,7 @@ public class AmqpBrokerConfigTest {
                 + " groupId = \"" + groupId + "\"\n"
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "consumerThreadPoolQueueCapacity");
@@ -194,6 +204,7 @@ public class AmqpBrokerConfigTest {
                 + " durable = " + durable + "\n"
                 + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
                 + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + " requeueRejectedMessages = " + requeueRejectedMessages + "\n"
                 + "}";
 
         testMandatoryConfigurationOption(configStr, "charsetName");
@@ -218,6 +229,24 @@ public class AmqpBrokerConfigTest {
 
         AmqpBrokerConfig.AmqpBrokerConfigBuilder builder = createConfigBuilder(configStr);
         builder.build();
+    }
+
+    @Test
+    public void testRequeueRejectedMessagesOption() {
+        String configStr = "config.amqp {"
+                + " charsetName = \"" + charsetName + "\"\n"
+                + " host = \"" + host + "\"\n"
+                + " port = \"" + port + "\"\n"
+                + " username = \"" + username + "\"\n"
+                + " password = \"" + password + "\"\n"
+                + " virtualHost = \"" + virtualHost + "\"\n"
+                + " groupId = \"" + groupId + "\"\n"
+                + " durable = " + durable + "\n"
+                + " consumerThreadPoolSize = " + consumerThreadPoolSize + "\n"
+                + " consumerThreadPoolQueueCapacity = " + consumerThreadPoolQueueCapacity + "\n"
+                + "}";
+
+        testMandatoryConfigurationOption(configStr, "requeueRejectedMessages");
     }
 
     private void testMandatoryConfigurationOption(String configStr, String path) {

--- a/cli/src/main/resources/application.conf
+++ b/cli/src/main/resources/application.conf
@@ -21,7 +21,8 @@ msbConfig {
     durable = false
     consumerThreadPoolSize = 5
     # -1 means unlimited
-    consumerThreadPoolQueueCapacity = -1
+    consumerThreadPoolQueueCapacity = 20
+    requeueRejectedMessages = true
   }
 
 }

--- a/examples/src/main/resources/application.conf
+++ b/examples/src/main/resources/application.conf
@@ -24,7 +24,8 @@ msbConfig {
     durable = false
     consumerThreadPoolSize = 5
     # -1 means unlimited
-    consumerThreadPoolQueueCapacity = -1
+    consumerThreadPoolQueueCapacity = 20
+    requeueRejectedMessages = true
   }
 
 }


### PR DESCRIPTION
The issue was that when a message could not be put in the executor service due to `RejectedExecutionException` the message left unacked and sat in RabbitMQ queue until the microservice shutdown.

To overcome this issue we send _reject_ message back to broker which causes the message either to be requeued or skipped (depending on value `requeueRejectedMessages` from configuration file).

One implication is that now we ack a message after it is successfully put in the queue and not after it has been processed.
