### PR TITLE
Fixed error when topics.response is absent in the incoming message

### DIFF
--- a/core/src/main/java/io/github/tcdl/msb/impl/NoopResponderImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/NoopResponderImpl.java
@@ -1,0 +1,38 @@
+package io.github.tcdl.msb.impl;
+
+import io.github.tcdl.msb.api.Responder;
+import io.github.tcdl.msb.api.message.Message;
+import io.github.tcdl.msb.api.message.payload.Payload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dummy implementation of {@link Responder} that is not able to send responses and acks.
+ */
+public class NoopResponderImpl implements Responder {
+    private static final Logger LOG = LoggerFactory.getLogger(NoopResponderImpl.class);
+
+    private Message originalMessage;
+
+    public NoopResponderImpl(Message originalMessage) {
+        this.originalMessage = originalMessage;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void sendAck(Integer timeoutMs, Integer responsesRemaining) {
+        LOG.error("Cannot send ack because response topic is unknown. Incoming message: {}", originalMessage);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void send(Payload<?, ?, ?, ?> responsePayload) {
+        LOG.error("Cannot send response because response topic is unknown. Incoming message: {}", originalMessage);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Message getOriginalMessage() {
+        return originalMessage;
+    }
+}

--- a/core/src/main/java/io/github/tcdl/msb/impl/ResponderImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ResponderImpl.java
@@ -71,9 +71,7 @@ public class ResponderImpl implements Responder {
         Validate.notNull(originalMessage.getTopics(), "the 'originalMessage.topics' must not be null");
     }
 
-    /**
-     * @return original message which was received
-     */
+    /** {@inheritDoc} */
     public Message getOriginalMessage() {
         return this.originalMessage;
     }

--- a/core/src/test/java/io/github/tcdl/msb/impl/ResponderServerImplTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/impl/ResponderServerImplTest.java
@@ -1,18 +1,12 @@
 package io.github.tcdl.msb.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.anyObject;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.tcdl.msb.ChannelManager;
 import io.github.tcdl.msb.MessageHandler;
+import io.github.tcdl.msb.Producer;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.RequestOptions;
+import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.ResponderServer;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.payload.Payload;
@@ -21,6 +15,18 @@ import io.github.tcdl.msb.support.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class ResponderServerImplTest {
 
@@ -134,5 +140,55 @@ public class ResponderServerImplTest {
         verify(responder).send(responseCaptor.capture());
         assertEquals(ResponderServer.INTERNAL_SERVER_ERROR_CODE, responseCaptor.getValue().getStatusCode().intValue());
         assertEquals(exceptionMessage, responseCaptor.getValue().getStatusMessage());
+    }
+
+    @Test
+    public void testCreateResponderWithResponseTopic() {
+        ResponderServer.RequestHandler<MyPayload> handler = (request, responder) -> {
+        };
+
+        ChannelManager mockChannelManager = mock(ChannelManager.class);
+        Producer mockProducer = mock(Producer.class);
+        when(mockChannelManager.findOrCreateProducer(anyString())).thenReturn(mockProducer);
+        MsbContextImpl msbContext1 = new TestUtils.TestMsbContextBuilder()
+                .withChannelManager(mockChannelManager)
+                .build();
+
+        ResponderServerImpl responderServer = ResponderServerImpl
+                .create(TOPIC, messageTemplate, msbContext1, handler, new TypeReference<MyPayload>() {});
+
+        Message incomingMessage = TestUtils.createMsbRequestMessageNoPayload(TOPIC);
+        Responder responder = responderServer.createResponder(incomingMessage);
+        assertEquals(incomingMessage, responder.getOriginalMessage());
+
+        responder.sendAck(1, 1);
+        responder.send(new MyPayload());
+
+        // Verify that 2 messages were published
+        verify(mockProducer, times(2)).publish(any(Message.class));
+    }
+
+    @Test
+    public void testCreateResponderNoResponseTopic() {
+        ResponderServer.RequestHandler<MyPayload> handler = (request, responder) -> {
+        };
+
+        ChannelManager mockChannelManager = mock(ChannelManager.class);
+        MsbContextImpl msbContext = new TestUtils.TestMsbContextBuilder()
+                .withChannelManager(mockChannelManager)
+                .build();
+
+        ResponderServerImpl responderServer = ResponderServerImpl
+                .create(TOPIC, messageTemplate, msbContext, handler, new TypeReference<MyPayload>() {});
+
+        Message incomingMessage = TestUtils.createMsbBroadcastMessageNoPayload(TOPIC);
+        Responder responder = responderServer.createResponder(incomingMessage);
+        assertEquals(incomingMessage, responder.getOriginalMessage());
+
+        responder.sendAck(1, 1);
+        responder.send(new MyPayload());
+
+        // Verify that no messages were published
+        verifyZeroInteractions(mockChannelManager);
     }
 }

--- a/core/src/test/java/io/github/tcdl/msb/support/TestUtils.java
+++ b/core/src/test/java/io/github/tcdl/msb/support/TestUtils.java
@@ -85,10 +85,19 @@ public class TestUtils {
 
     public static Message createMsbRequestMessageNoPayload(String namespace) {
         MsbConfig msbConf = createMsbConfigurations();
+        return createMsbRequestMessageNoPayload(namespace, namespace + ":response:" +
+                msbConf.getServiceDetails().getInstanceId());
+    }
+
+    public static Message createMsbBroadcastMessageNoPayload(String namespace) {
+        return createMsbRequestMessageNoPayload(namespace, null);
+    }
+
+    public static Message createMsbRequestMessageNoPayload(String namespace, String replyTopic) {
+        MsbConfig msbConf = createMsbConfigurations();
         Clock clock = Clock.systemDefaultZone();
 
-        Topics topic = new Topics(namespace, namespace + ":response:" +
-                msbConf.getServiceDetails().getInstanceId());
+        Topics topic = new Topics(namespace, replyTopic);
 
         MetaMessage.Builder metaBuilder = createSimpleMetaBuilder(msbConf, clock);
         return new Message.Builder()


### PR DESCRIPTION
`Responder` has 2 distinct responsibilities now:
1.  Provide a way to send acks and responses
2. Expose original message to microservice developer

This solution has the following drawbacks:
1. Mix of purposes in a single class (`Responder`)
2. Non-obvious way to obtain original message
3.  Necessity of dummy `NoopResponderImpl`

Proposed solution:
- Include original message in the handlers signature:

``` java
    interface RequestHandler<T extends Payload> {
        void process(Message, originalMessage, T request, Responder responder) throws Exception;
    }
```

What do you think about that?
