### PR TITLE
Omni payload

### DIFF
--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MsbTestHelper.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MsbTestHelper.java
@@ -12,7 +12,7 @@ import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.ResponderServer;
 import io.github.tcdl.msb.api.message.Acknowledge;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.support.Utils;
 
@@ -71,47 +71,47 @@ public class MsbTestHelper {
         return getPayloadMapper(DEFAULT_CONTEXT_NAME);
     }
 
-    public Requester<Payload<Object, Object, Object, Map<String, Object>>> createRequester(String namespace, Integer numberOfResponses) {
+    public Requester<RestPayload<Object, Object, Object, Map<String, Object>>> createRequester(String namespace, Integer numberOfResponses) {
         return createRequester(DEFAULT_CONTEXT_NAME, namespace, numberOfResponses, null, null);
     }
 
-    public Requester<Payload<Object, Object, Object, Map<String, Object>>> createRequester(String contextName, String namespace, Integer numberOfResponses) {
+    public Requester<RestPayload<Object, Object, Object, Map<String, Object>>> createRequester(String contextName, String namespace, Integer numberOfResponses) {
         return createRequester(contextName, namespace, numberOfResponses, null, null);
     }
 
-    public Requester<Payload<Object, Object, Object, Map<String, Object>>> createRequester(String namespace, Integer numberOfResponses, Integer ackTimeout, Integer responseTimeout) {
+    public Requester<RestPayload<Object, Object, Object, Map<String, Object>>> createRequester(String namespace, Integer numberOfResponses, Integer ackTimeout, Integer responseTimeout) {
         return createRequester(DEFAULT_CONTEXT_NAME, namespace, numberOfResponses, ackTimeout, responseTimeout);
     }
 
-    public Requester<Payload<Object, Object, Object, Map<String, Object>>> createRequester(String contextName, String namespace, Integer numberOfResponses, Integer ackTimeout, Integer responseTimeout) {
+    public Requester<RestPayload<Object, Object, Object, Map<String, Object>>> createRequester(String contextName, String namespace, Integer numberOfResponses, Integer ackTimeout, Integer responseTimeout) {
         RequestOptions options = new RequestOptions.Builder()
                 .withWaitForResponses(numberOfResponses)
                 .withAckTimeout(Utils.ifNull(ackTimeout, 5000))
                 .withResponseTimeout(Utils.ifNull(responseTimeout, 15000))
                 .build();
         return getContext(contextName).getObjectFactory().createRequester(namespace, options,
-                new TypeReference<Payload<Object, Object, Object, Map<String, Object>>>() {
+                new TypeReference<RestPayload<Object, Object, Object, Map<String, Object>>>() {
                 });
     }
 
-    public void sendRequest(Requester<Payload<Object, Object, Object, Map<String, Object>>> requester, Integer waitForResponses, Callback<Payload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
+    public void sendRequest(Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester, Integer waitForResponses, Callback<RestPayload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
         sendRequest(DEFAULT_CONTEXT_NAME, requester, "QUERY", null, true, waitForResponses, null, responseCallback);
     }
 
-    public void sendRequest(String contextName, Requester<Payload<Object, Object, Object, Map<String, Object>>> requester, Integer waitForResponses, Callback<Payload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
+    public void sendRequest(String contextName, Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester, Integer waitForResponses, Callback<RestPayload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
         sendRequest(contextName, requester, "QUERY", null, true, waitForResponses, null, responseCallback);
     }
 
-    public void sendRequest(Requester<Payload<Object, Object, Object, Map<String, Object>>> requester, String query, String body, boolean waitForAck, Integer waitForResponses,
+    public void sendRequest(Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester, String query, String body, boolean waitForAck, Integer waitForResponses,
             Callback<Acknowledge> ackCallback,
-            Callback<Payload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
+            Callback<RestPayload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
 
         sendRequest(DEFAULT_CONTEXT_NAME, requester, query, body, waitForAck, waitForResponses, ackCallback, responseCallback);
     }
 
-    public void sendRequest(String contextName, Requester<Payload<Object, Object, Object, Map<String, Object>>> requester, String query, String body, boolean waitForAck, Integer waitForResponses,
+    public void sendRequest(String contextName, Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester, String query, String body, boolean waitForAck, Integer waitForResponses,
             Callback<Acknowledge> ackCallback,
-            Callback<Payload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
+            Callback<RestPayload<Object, Object, Object, Map<String, Object>>> responseCallback) throws Exception {
 
         requester.onAcknowledge(acknowledge -> {
             System.out.println(">>> ACKNOWLEDGE: " + acknowledge);
@@ -129,17 +129,17 @@ public class MsbTestHelper {
         requester.publish(createPayload(contextName, query, body));
     }
 
-    public ResponderServer createResponderServer(String namespace, ResponderServer.RequestHandler<Payload> requestHandler) {
+    public ResponderServer createResponderServer(String namespace, ResponderServer.RequestHandler<RestPayload> requestHandler) {
         return createResponderServer(DEFAULT_CONTEXT_NAME, namespace, requestHandler);
     }
 
-    public ResponderServer createResponderServer(String contextName, String namespace, ResponderServer.RequestHandler<Payload> requestHandler) {
+    public ResponderServer createResponderServer(String contextName, String namespace, ResponderServer.RequestHandler<RestPayload> requestHandler) {
         MessageTemplate options = new MessageTemplate();
         System.out.println(">>> RESPONDER SERVER on: " + namespace);
         return getContext(contextName).getObjectFactory().createResponderServer(namespace, options, requestHandler);
     }
 
-    public <T extends Payload> ResponderServer createResponderServer(String namespace, ResponderServer.RequestHandler<T> requestHandler, Class<T> payloadClass) {
+    public <T extends RestPayload> ResponderServer createResponderServer(String namespace, ResponderServer.RequestHandler<T> requestHandler, Class<T> payloadClass) {
         MessageTemplate options = new MessageTemplate();
         System.out.println(">>> RESPONDER SERVER on: " + namespace);
         return getDefaultContext().getObjectFactory().createResponderServer(namespace, options, requestHandler, payloadClass);
@@ -169,9 +169,9 @@ public class MsbTestHelper {
         getDefaultContext().shutdown();
     }
 
-    public Payload createPayload(String contextName, String query, String body) {
+    public RestPayload createPayload(String contextName, String query, String body) {
         ObjectMapper mapper = ((MsbContextImpl) getContext(contextName)).getPayloadMapper();
-        return new Payload.Builder<Map, Object, Object, Map>()
+        return new RestPayload.Builder<Map, Object, Object, Map>()
                 .withQuery(Utils.fromJson("{\"q\": \"" + query + "\"}", Map.class, mapper))
                 .withBody(Utils.fromJson("{\"body\": \"" + body + "\"}", Map.class, mapper))
                 .build();

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MsbTestHelper.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MsbTestHelper.java
@@ -136,7 +136,7 @@ public class MsbTestHelper {
     public ResponderServer createResponderServer(String contextName, String namespace, ResponderServer.RequestHandler<RestPayload> requestHandler) {
         MessageTemplate options = new MessageTemplate();
         System.out.println(">>> RESPONDER SERVER on: " + namespace);
-        return getContext(contextName).getObjectFactory().createResponderServer(namespace, options, requestHandler);
+        return getContext(contextName).getObjectFactory().createResponderServer(namespace, options, requestHandler, RestPayload.class);
     }
 
     public <T extends RestPayload> ResponderServer createResponderServer(String namespace, ResponderServer.RequestHandler<T> requestHandler, Class<T> payloadClass) {

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MultipleRequester.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MultipleRequester.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.tcdl.msb.api.MsbContext;
 import io.github.tcdl.msb.api.MsbContextBuilder;
 import io.github.tcdl.msb.api.RequestOptions;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -48,12 +48,12 @@ public class MultipleRequester {
                 .build();
 
         SearchRequest request = new SearchRequest(requestId, queryString);
-        Payload requestPayload = new Payload.Builder<Object, Object, Object, SearchRequest>()
+        RestPayload requestPayload = new RestPayload.Builder<Object, Object, Object, SearchRequest>()
                 .withBody(request)
                 .build();
 
         CompletableFuture.supplyAsync(() -> {
-            msbContext.getObjectFactory().createRequester(namespace, options, new TypeReference<Payload<?, ?, ?, Map>>() {})
+            msbContext.getObjectFactory().createRequester(namespace, options, new TypeReference<RestPayload<?, ?, ?, Map>>() {})
                     .onAcknowledge(acknowledge ->
                                     System.out.println(">>> ACK timeout: " + acknowledge.getTimeoutMs())
                     )

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MultipleRequesterResponder.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MultipleRequesterResponder.java
@@ -1,7 +1,7 @@
 package io.github.tcdl.msb.acceptance;
 
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 
 import java.util.Map;
@@ -56,7 +56,7 @@ public class MultipleRequesterResponder {
     }
 
     private Future<String> createAndRunRequester(ExecutorService executor, String namespace) {
-        Requester<Payload<Object, Object, Object, Map<String, Object>>> requester = util.createRequester(namespace, NUMBER_OF_RESPONSES, null, 5000);
+        Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester = util.createRequester(namespace, NUMBER_OF_RESPONSES, null, 5000);
         Future<String> future = executor.submit(new Callable<String>() {
             String result = null;
 

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MultipleResponder.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MultipleResponder.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.MsbContext;
 import io.github.tcdl.msb.api.MsbContextBuilder;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 import java.util.Map;
 
@@ -26,10 +26,10 @@ public class MultipleResponder {
             String requestId = (String) requestBody.get("requestId");
             SearchResponse response = new SearchResponse(requestId, "response");
             System.out.println(">>> SENDING response in request to " + requestId);
-            responder.send(new Payload.Builder<Object, Object, Object, SearchResponse>()
+            responder.send(new RestPayload.Builder<Object, Object, Object, SearchResponse>()
                     .withBody(response)
                     .build());
-        }, new TypeReference<Payload<Object, Object, Object, Map>>() {})
+        }, new TypeReference<RestPayload<Object, Object, Object, Map>>() {})
         .listen();
     }
 

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/RequesterResponderTest.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/RequesterResponderTest.java
@@ -2,7 +2,7 @@ package io.github.tcdl.msb.acceptance;
 
 import io.github.tcdl.msb.acceptance.payload.MyPayload;
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -39,7 +39,7 @@ public class RequesterResponderTest {
         .listen();
 
         // sending a request
-        Requester<Payload<Object, Object, Object, Map<String, Object>>> requester = helper.createRequester(NAMESPACE, NUMBER_OF_RESPONSES);
+        Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester = helper.createRequester(NAMESPACE, NUMBER_OF_RESPONSES);
         passedLatch = new CountDownLatch(1);
         helper.sendRequest(requester, NUMBER_OF_RESPONSES, payload -> passedLatch.countDown());
     }

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/SimpleRequester.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/SimpleRequester.java
@@ -1,7 +1,7 @@
 package io.github.tcdl.msb.acceptance;
 
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -30,7 +30,7 @@ public class SimpleRequester {
     }
 
     public void runSimpleRequesterExample(String... expectedResponses) throws Exception {
-        Requester<Payload<Object, Object, Object, Map<String, Object>>> requester = helper.createRequester(namespace, NUMBER_OF_RESPONSES);
+        Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester = helper.createRequester(namespace, NUMBER_OF_RESPONSES);
 
         passedLatch = new CountDownLatch(expectedResponses != null ? expectedResponses.length : 0);
 

--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/payload/MyPayload.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/payload/MyPayload.java
@@ -1,6 +1,6 @@
 package io.github.tcdl.msb.acceptance.payload;
 
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
-public class MyPayload extends Payload<Query, Object, Object, Body> {
+public class MyPayload extends RestPayload<Query, Object, Object, Body> {
 }

--- a/acceptance/src/test/java/io/github/tcdl/msb/acceptance/bdd/steps/AsyncRequesterSteps.java
+++ b/acceptance/src/test/java/io/github/tcdl/msb/acceptance/bdd/steps/AsyncRequesterSteps.java
@@ -1,7 +1,7 @@
 package io.github.tcdl.msb.acceptance.bdd.steps;
 
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 
@@ -25,7 +25,7 @@ public class AsyncRequesterSteps extends MsbSteps {
 
         for (int i = 0; i < numberOfRequesters; i++) {
             CompletableFuture.supplyAsync(() -> {
-                Requester<Payload<Object, Object, Object, Map<String, Object>>> requester = helper.createRequester(namespace, 1);
+                Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester = helper.createRequester(namespace, 1);
                 try {
                     helper.sendRequest(requester, query, null, true, 1, null, this::onResponse);
                 } catch (Exception e) {
@@ -42,7 +42,7 @@ public class AsyncRequesterSteps extends MsbSteps {
         assertEquals("Some requests were not responded", 0, await.getCount());
     }
 
-    private void onResponse(Payload payload) {
+    private void onResponse(RestPayload payload) {
         await.countDown();
     }
 }

--- a/acceptance/src/test/java/io/github/tcdl/msb/acceptance/bdd/steps/RequesterResponderSteps.java
+++ b/acceptance/src/test/java/io/github/tcdl/msb/acceptance/bdd/steps/RequesterResponderSteps.java
@@ -3,7 +3,7 @@ package io.github.tcdl.msb.acceptance.bdd.steps;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.tcdl.msb.acceptance.MsbTestHelper;
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.support.Utils;
 import org.hamcrest.Matchers;
 import org.jbehave.core.annotations.Given;
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 public class RequesterResponderSteps extends MsbSteps {
 
-    private Requester<Payload<Object, Object, Object, Map<String, Object>>> requester;
+    private Requester<RestPayload<Object, Object, Object, Map<String, Object>>> requester;
     private String responseBody;
     private Map<String, Object> receivedResponse;
 
@@ -36,7 +36,7 @@ public class RequesterResponderSteps extends MsbSteps {
         ObjectMapper mapper = helper.getPayloadMapper(contextName);
         helper.createResponderServer(contextName, namespace, (request, responder) -> {
             if (responseBody != null) {
-                Payload payload = new Payload.Builder<Object, Object, Object, Map>()
+                RestPayload payload = new RestPayload.Builder<Object, Object, Object, Map>()
                         .withBody(Utils.fromJson(responseBody, Map.class, mapper))
                         .build();
                 responder.send(payload);
@@ -81,7 +81,7 @@ public class RequesterResponderSteps extends MsbSteps {
         helper.sendRequest(requester, null, body, true, 1, null, this::onResponse);
     }
 
-    private void onResponse(Payload<Object, Object, Object, Map<String, Object>> payload) {
+    private void onResponse(RestPayload<Object, Object, Object, Map<String, Object>> payload) {
         receivedResponse = payload.getBody();
     }
 

--- a/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
@@ -1,7 +1,7 @@
 package io.github.tcdl.msb.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
 
@@ -13,12 +13,12 @@ import java.lang.reflect.Type;
 public interface ObjectFactory {
 
     /**
-     * Convenience method that specifies response payload type as {@link Payload}
+     * Convenience method that specifies response payload type as {@link RestPayload}
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default Requester<Payload> createRequester(String namespace, RequestOptions requestOptions) {
-        return createRequester(namespace, requestOptions, Payload.class);
+    default Requester<RestPayload> createRequester(String namespace, RequestOptions requestOptions) {
+        return createRequester(namespace, requestOptions, RestPayload.class);
     }
 
     /**
@@ -26,7 +26,7 @@ public interface ObjectFactory {
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default <T extends Payload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, Class<T> payloadClass) {
+    default <T extends RestPayload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, Class<T> payloadClass) {
         return createRequester(namespace, requestOptions, new TypeReference<T>() {
             @Override
             public Type getType() {
@@ -41,16 +41,16 @@ public interface ObjectFactory {
      * @param payloadTypeReference  expected payload type of response messages
      * @return new instance of a {@link Requester} with original message
      */
-    <T extends Payload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference);
+    <T extends RestPayload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference);
 
     /**
-     * Convenience method that specifies incoming payload type as {@link Payload}
+     * Convenience method that specifies incoming payload type as {@link RestPayload}
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default ResponderServer<Payload> createResponderServer(String namespace, MessageTemplate messageTemplate,
-            ResponderServer.RequestHandler<Payload> requestHandler) {
-        return createResponderServer(namespace, messageTemplate, requestHandler, Payload.class);
+    default ResponderServer<RestPayload> createResponderServer(String namespace, MessageTemplate messageTemplate,
+            ResponderServer.RequestHandler<RestPayload> requestHandler) {
+        return createResponderServer(namespace, messageTemplate, requestHandler, RestPayload.class);
     }
 
     /**
@@ -58,7 +58,7 @@ public interface ObjectFactory {
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default <T extends Payload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    default <T extends RestPayload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, Class<T> payloadClass) {
         return createResponderServer(namespace, messageTemplate, requestHandler, new TypeReference<T>() {
             @Override
@@ -75,7 +75,7 @@ public interface ObjectFactory {
      * @param payloadTypeReference      expected payload type of incoming messages
      * @return new instance of a {@link ResponderServer} that unmarshals payload into specified payload type
      */
-    <T extends Payload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    <T extends RestPayload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference);
 
     /**

--- a/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
@@ -1,7 +1,7 @@
 package io.github.tcdl.msb.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
 
@@ -13,12 +13,12 @@ import java.lang.reflect.Type;
 public interface ObjectFactory {
 
     /**
-     * Convenience method that specifies response payload type as {@link RestPayload}
+     * Convenience method that specifies response payload type as {@link JsonNode}
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default Requester<RestPayload> createRequester(String namespace, RequestOptions requestOptions) {
-        return createRequester(namespace, requestOptions, RestPayload.class); // TODO use JsonNode here?
+    default Requester<JsonNode> createRequester(String namespace, RequestOptions requestOptions) {
+        return createRequester(namespace, requestOptions, JsonNode.class);
     }
 
     /**
@@ -44,13 +44,13 @@ public interface ObjectFactory {
     <T> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference);
 
     /**
-     * Convenience method that specifies incoming payload type as {@link RestPayload}
+     * Convenience method that specifies incoming payload type as {@link JsonNode}
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
     default ResponderServer createResponderServer(String namespace, MessageTemplate messageTemplate,
-            ResponderServer.RequestHandler<RestPayload> requestHandler) {
-        return createResponderServer(namespace, messageTemplate, requestHandler, RestPayload.class); // TODO use JsonNode here?
+            ResponderServer.RequestHandler<JsonNode> requestHandler) {
+        return createResponderServer(namespace, messageTemplate, requestHandler, JsonNode.class);
     }
 
     /**

--- a/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
@@ -48,7 +48,7 @@ public interface ObjectFactory {
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default ResponderServer<RestPayload> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    default ResponderServer createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<RestPayload> requestHandler) {
         return createResponderServer(namespace, messageTemplate, requestHandler, RestPayload.class); // TODO use JsonNode here?
     }
@@ -58,7 +58,7 @@ public interface ObjectFactory {
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default <T> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    default <T> ResponderServer createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, Class<T> payloadClass) {
         return createResponderServer(namespace, messageTemplate, requestHandler, new TypeReference<T>() {
             @Override
@@ -75,7 +75,7 @@ public interface ObjectFactory {
      * @param payloadTypeReference      expected payload type of incoming messages
      * @return new instance of a {@link ResponderServer} that unmarshals payload into specified payload type
      */
-    <T> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    <T> ResponderServer createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference);
 
     /**

--- a/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ObjectFactory.java
@@ -18,7 +18,7 @@ public interface ObjectFactory {
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
     default Requester<RestPayload> createRequester(String namespace, RequestOptions requestOptions) {
-        return createRequester(namespace, requestOptions, RestPayload.class);
+        return createRequester(namespace, requestOptions, RestPayload.class); // TODO use JsonNode here?
     }
 
     /**
@@ -26,7 +26,7 @@ public interface ObjectFactory {
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default <T extends RestPayload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, Class<T> payloadClass) {
+    default <T> Requester<T> createRequester(String namespace, RequestOptions requestOptions, Class<T> payloadClass) {
         return createRequester(namespace, requestOptions, new TypeReference<T>() {
             @Override
             public Type getType() {
@@ -41,7 +41,7 @@ public interface ObjectFactory {
      * @param payloadTypeReference  expected payload type of response messages
      * @return new instance of a {@link Requester} with original message
      */
-    <T extends RestPayload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference);
+    <T> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference);
 
     /**
      * Convenience method that specifies incoming payload type as {@link RestPayload}
@@ -50,7 +50,7 @@ public interface ObjectFactory {
      */
     default ResponderServer<RestPayload> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<RestPayload> requestHandler) {
-        return createResponderServer(namespace, messageTemplate, requestHandler, RestPayload.class);
+        return createResponderServer(namespace, messageTemplate, requestHandler, RestPayload.class); // TODO use JsonNode here?
     }
 
     /**
@@ -58,7 +58,7 @@ public interface ObjectFactory {
      *
      * See {@link #createRequester(String, RequestOptions, TypeReference)}
      */
-    default <T extends RestPayload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    default <T> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, Class<T> payloadClass) {
         return createResponderServer(namespace, messageTemplate, requestHandler, new TypeReference<T>() {
             @Override
@@ -75,7 +75,7 @@ public interface ObjectFactory {
      * @param payloadTypeReference      expected payload type of incoming messages
      * @return new instance of a {@link ResponderServer} that unmarshals payload into specified payload type
      */
-    <T extends RestPayload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    <T> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference);
 
     /**

--- a/core/src/main/java/io/github/tcdl/msb/api/RequestOptions.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/RequestOptions.java
@@ -1,6 +1,6 @@
 package io.github.tcdl.msb.api;
 
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * Specifies waiting policy (for acknowledgements and responses) for requests sent using {@link Requester}.
@@ -69,7 +69,7 @@ public class RequestOptions {
                 + "]";
     }
 
-    public static class Builder<T extends Payload> {
+    public static class Builder<T extends RestPayload> {
 
         private Integer ackTimeout;
         private Integer responseTimeout;

--- a/core/src/main/java/io/github/tcdl/msb/api/RequestOptions.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/RequestOptions.java
@@ -1,7 +1,5 @@
 package io.github.tcdl.msb.api;
 
-import io.github.tcdl.msb.api.message.payload.RestPayload;
-
 /**
  * Specifies waiting policy (for acknowledgements and responses) for requests sent using {@link Requester}.
  */
@@ -69,29 +67,29 @@ public class RequestOptions {
                 + "]";
     }
 
-    public static class Builder<T extends RestPayload> {
+    public static class Builder {
 
         private Integer ackTimeout;
         private Integer responseTimeout;
         private Integer waitForResponses;
         private MessageTemplate messageTemplate;
 
-        public Builder<T> withAckTimeout(Integer ackTimeout) {
+        public Builder withAckTimeout(Integer ackTimeout) {
             this.ackTimeout = ackTimeout;
             return this;
         }
 
-        public Builder<T> withResponseTimeout(Integer responseTimeout) {
+        public Builder withResponseTimeout(Integer responseTimeout) {
             this.responseTimeout = responseTimeout;
             return this;
         }
 
-        public Builder<T> withWaitForResponses(Integer waitForResponses) {
+        public Builder withWaitForResponses(Integer waitForResponses) {
             this.waitForResponses = waitForResponses;
             return this;
         }
 
-        public Builder<T> withMessageTemplate(MessageTemplate messageTemplate) {
+        public Builder withMessageTemplate(MessageTemplate messageTemplate) {
             this.messageTemplate = messageTemplate;
             return this;
         }

--- a/core/src/main/java/io/github/tcdl/msb/api/Requester.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/Requester.java
@@ -68,7 +68,6 @@ public interface Requester<T> {
      */
     Requester<T> onAcknowledge(Callback<Acknowledge> acknowledgeHandler);
 
-    // TODO Fix reference to RestPayload in javadocs
     /**
      * Registers a callback to be called when response {@link Message} with payload part set of type {@literal<}T{@literal>} is received.
      *

--- a/core/src/main/java/io/github/tcdl/msb/api/Requester.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/Requester.java
@@ -4,7 +4,6 @@ import io.github.tcdl.msb.api.exception.ChannelException;
 import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * {@link Requester} enable user send message to bus and process responses for this messages if any expected.
@@ -13,12 +12,9 @@ import io.github.tcdl.msb.api.message.payload.RestPayload;
  * response mechanism in case we create Requester with {@literal RequestOptions.waitForResponses => 0} and received Acknowledgement response
  * before RequestOptions.ackTimeout or RequestOptions.responseTimeout (takes max of two).
  *
- * Please note: RequestOptions.waitForResponses represent number of response messages with {@link RestPayload} set and in case we received
- * all expected before RequestOptions.responseTimeout we don't wait for Acknowledgement response and RequestOptions.ackTimeout is not used.
- *
  * @param <T> expected payload type of response messages
  */
-public interface Requester<T extends RestPayload> {
+public interface Requester<T> {
 
     /**
      * Wraps a payload with protocol information and sends to bus.
@@ -28,7 +24,7 @@ public interface Requester<T extends RestPayload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(RestPayload<?, ?, ?, ?> requestPayload);
+    void publish(Object requestPayload);
 
     /**
      * Wraps a payload with protocol information and sends to bus.
@@ -39,7 +35,7 @@ public interface Requester<T extends RestPayload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(RestPayload<?, ?, ?, ?> requestPayload, String tag);
+    void publish(Object requestPayload, String tag);
 
     /**
      * Wraps a payload with protocol information, preserves original message and sends to bus.
@@ -51,7 +47,7 @@ public interface Requester<T extends RestPayload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage, String tag);
+    void publish(Object requestPayload, Message originalMessage, String tag);
 
     /**
      * Wraps a payload with protocol information, preserves original message and sends to bus.
@@ -62,7 +58,7 @@ public interface Requester<T extends RestPayload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage);
+    void publish(Object requestPayload, Message originalMessage);
 
     /**
      * Registers a callback to be called when {@link Message} with {@link Acknowledge} part set is received.
@@ -72,17 +68,18 @@ public interface Requester<T extends RestPayload> {
      */
     Requester<T> onAcknowledge(Callback<Acknowledge> acknowledgeHandler);
 
+    // TODO Fix reference to RestPayload in javadocs
     /**
-     * Registers a callback to be called when response {@link Message} with {@link RestPayload} part set of type {@literal<}T{@literal>} is received.
+     * Registers a callback to be called when response {@link Message} with payload part set of type {@literal<}T{@literal>} is received.
      *
      * @param responseHandler callback to be called
      * @return requester
-     * @throws JsonConversionException if unable to convert {@link RestPayload} to type {@literal<}T{@literal>}
+     * @throws JsonConversionException if unable to convert payload to type {@literal<}T{@literal>}
      */
     Requester<T> onResponse(Callback<T> responseHandler);
 
     /**
-     * Registers a callback to be called when response {@link Message} with {@link RestPayload} part set of is received.
+     * Registers a callback to be called when response {@link Message} with payload part set of is received.
      *
      * @param responseHandler callback to be called
      * @return requester

--- a/core/src/main/java/io/github/tcdl/msb/api/Requester.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/Requester.java
@@ -4,7 +4,7 @@ import io.github.tcdl.msb.api.exception.ChannelException;
 import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * {@link Requester} enable user send message to bus and process responses for this messages if any expected.
@@ -13,12 +13,12 @@ import io.github.tcdl.msb.api.message.payload.Payload;
  * response mechanism in case we create Requester with {@literal RequestOptions.waitForResponses => 0} and received Acknowledgement response
  * before RequestOptions.ackTimeout or RequestOptions.responseTimeout (takes max of two).
  *
- * Please note: RequestOptions.waitForResponses represent number of response messages with {@link Payload} set and in case we received
+ * Please note: RequestOptions.waitForResponses represent number of response messages with {@link RestPayload} set and in case we received
  * all expected before RequestOptions.responseTimeout we don't wait for Acknowledgement response and RequestOptions.ackTimeout is not used.
  *
  * @param <T> expected payload type of response messages
  */
-public interface Requester<T extends Payload> {
+public interface Requester<T extends RestPayload> {
 
     /**
      * Wraps a payload with protocol information and sends to bus.
@@ -28,7 +28,7 @@ public interface Requester<T extends Payload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(Payload<?, ?, ?, ?> requestPayload);
+    void publish(RestPayload<?, ?, ?, ?> requestPayload);
 
     /**
      * Wraps a payload with protocol information and sends to bus.
@@ -39,7 +39,7 @@ public interface Requester<T extends Payload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(Payload<?, ?, ?, ?> requestPayload, String tag);
+    void publish(RestPayload<?, ?, ?, ?> requestPayload, String tag);
 
     /**
      * Wraps a payload with protocol information, preserves original message and sends to bus.
@@ -51,7 +51,7 @@ public interface Requester<T extends Payload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(Payload<?, ?, ?, ?> requestPayload, Message originalMessage, String tag);
+    void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage, String tag);
 
     /**
      * Wraps a payload with protocol information, preserves original message and sends to bus.
@@ -62,7 +62,7 @@ public interface Requester<T extends Payload> {
      * @throws ChannelException if an error is encountered during publishing to bus
      * @throws JsonConversionException if unable to parse message to JSON before sending to bus
      */
-    void publish(Payload<?, ?, ?, ?> requestPayload, Message originalMessage);
+    void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage);
 
     /**
      * Registers a callback to be called when {@link Message} with {@link Acknowledge} part set is received.
@@ -73,16 +73,16 @@ public interface Requester<T extends Payload> {
     Requester<T> onAcknowledge(Callback<Acknowledge> acknowledgeHandler);
 
     /**
-     * Registers a callback to be called when response {@link Message} with {@link Payload} part set of type {@literal<}T{@literal>} is received.
+     * Registers a callback to be called when response {@link Message} with {@link RestPayload} part set of type {@literal<}T{@literal>} is received.
      *
      * @param responseHandler callback to be called
      * @return requester
-     * @throws JsonConversionException if unable to convert {@link Payload} to type {@literal<}T{@literal>}
+     * @throws JsonConversionException if unable to convert {@link RestPayload} to type {@literal<}T{@literal>}
      */
     Requester<T> onResponse(Callback<T> responseHandler);
 
     /**
-     * Registers a callback to be called when response {@link Message} with {@link Payload} part set of is received.
+     * Registers a callback to be called when response {@link Message} with {@link RestPayload} part set of is received.
      *
      * @param responseHandler callback to be called
      * @return requester

--- a/core/src/main/java/io/github/tcdl/msb/api/Responder.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/Responder.java
@@ -1,7 +1,7 @@
 package io.github.tcdl.msb.api;
 
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * Responsible for creating responses and acknowledgements and sending them to the bus.
@@ -21,7 +21,7 @@ public interface Responder {
      *
      * @param responsePayload payload which will be used to create response message
      */
-    void send(Payload<?, ?, ?, ?> responsePayload);
+    void send(RestPayload<?, ?, ?, ?> responsePayload);
 
     /**
      * @return original message to send a response to

--- a/core/src/main/java/io/github/tcdl/msb/api/Responder.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/Responder.java
@@ -1,7 +1,6 @@
 package io.github.tcdl.msb.api;
 
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * Responsible for creating responses and acknowledgements and sending them to the bus.
@@ -21,7 +20,7 @@ public interface Responder {
      *
      * @param responsePayload payload which will be used to create response message
      */
-    void send(RestPayload<?, ?, ?, ?> responsePayload);
+    void send(Object responsePayload);
 
     /**
      * @return original message to send a response to

--- a/core/src/main/java/io/github/tcdl/msb/api/ResponderServer.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ResponderServer.java
@@ -1,7 +1,5 @@
 package io.github.tcdl.msb.api;
 
-import io.github.tcdl.msb.api.message.payload.RestPayload;
-
 /**
  * {@link ResponderServer} enable user to listen on messages from the bus and executing microservice business logic.
  * Call to {@link #listen()} method will start listening on incoming messages from the bus.
@@ -11,7 +9,7 @@ import io.github.tcdl.msb.api.message.payload.RestPayload;
  *
  * @param <T> expected payload type of incoming message
  */
-public interface ResponderServer<T extends RestPayload> {
+public interface ResponderServer<T> {
 
     int INTERNAL_SERVER_ERROR_CODE = 500;
     int PAYLOAD_CONVERSION_ERROR_CODE = 422;
@@ -25,7 +23,7 @@ public interface ResponderServer<T extends RestPayload> {
     /**
      * Implementation of this interface contains business logic processed by microservice.
      */
-    interface RequestHandler<T extends RestPayload> {
+    interface RequestHandler<T> {
         /**
          * Execute business logic and send response.
          * @param request request received from a bus

--- a/core/src/main/java/io/github/tcdl/msb/api/ResponderServer.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ResponderServer.java
@@ -1,6 +1,6 @@
 package io.github.tcdl.msb.api;
 
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * {@link ResponderServer} enable user to listen on messages from the bus and executing microservice business logic.
@@ -11,7 +11,7 @@ import io.github.tcdl.msb.api.message.payload.Payload;
  *
  * @param <T> expected payload type of incoming message
  */
-public interface ResponderServer<T extends Payload> {
+public interface ResponderServer<T extends RestPayload> {
 
     int INTERNAL_SERVER_ERROR_CODE = 500;
     int PAYLOAD_CONVERSION_ERROR_CODE = 422;
@@ -25,7 +25,7 @@ public interface ResponderServer<T extends Payload> {
     /**
      * Implementation of this interface contains business logic processed by microservice.
      */
-    interface RequestHandler<T extends Payload> {
+    interface RequestHandler<T extends RestPayload> {
         /**
          * Execute business logic and send response.
          * @param request request received from a bus

--- a/core/src/main/java/io/github/tcdl/msb/api/ResponderServer.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/ResponderServer.java
@@ -6,10 +6,8 @@ package io.github.tcdl.msb.api;
  * And also it's required to implement interface {@link RequestHandler}. Implementation of this interface will be
  * business logic processed by microservice. Inside this logic we can use instance of {@link Responder} created by {@code ResponderServer}
  * for each message from bus, and can be used for sending responses back to bus.
- *
- * @param <T> expected payload type of incoming message
  */
-public interface ResponderServer<T> {
+public interface ResponderServer {
 
     int INTERNAL_SERVER_ERROR_CODE = 500;
     int PAYLOAD_CONVERSION_ERROR_CODE = 422;
@@ -18,7 +16,6 @@ public interface ResponderServer<T> {
      * Start listening for message on specified topic.
      */
      ResponderServer listen();
-
 
     /**
      * Implementation of this interface contains business logic processed by microservice.

--- a/core/src/main/java/io/github/tcdl/msb/api/message/payload/RestPayload.java
+++ b/core/src/main/java/io/github/tcdl/msb/api/message/payload/RestPayload.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 // Workaround to using setFieldVisibility on object mapper. It caused infinite recursion
 @JsonAutoDetect(getterVisibility = PROTECTED_AND_PUBLIC, setterVisibility = PROTECTED_AND_PUBLIC)
-public class Payload<Q, H, P, B> {
+public class RestPayload<Q, H, P, B> {
 
     /**
      * Response status code
@@ -55,11 +55,11 @@ public class Payload<Q, H, P, B> {
      */
     private byte[] bodyBuffer;
 
-    protected Payload() {
+    protected RestPayload() {
     }
 
     @JsonCreator
-    private Payload(
+    private RestPayload(
             @JsonProperty("statusCode") Integer statusCode,
             @JsonProperty("statusMessage") String statusMessage,
             @JsonProperty("query") Q query,
@@ -177,21 +177,21 @@ public class Payload<Q, H, P, B> {
             return this;
         }
 
-        public Payload<Q, H, P, B> build() {
-            return new Payload<>(statusCode, statusMessage, query, headers, params, body, bodyBuffer);
+        public RestPayload<Q, H, P, B> build() {
+            return new RestPayload<>(statusCode, statusMessage, query, headers, params, body, bodyBuffer);
         }
     }
 
     @Override
     public String toString() {
-        return String.format("Payload [statusCode=%s, statusMessage=%s, query=%s, headers=%s, params=%s, body=%s, bodyBuffer=%s]",
+        return String.format("RestPayload [statusCode=%s, statusMessage=%s, query=%s, headers=%s, params=%s, body=%s, bodyBuffer=%s]",
                 statusCode, statusMessage, query, headers, params, body, Arrays.toString(bodyBuffer));
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof Payload) {
-            Payload<?, ?, ?, ?> other = (Payload<?, ?, ?, ?>) obj;
+        if (obj instanceof RestPayload) {
+            RestPayload<?, ?, ?, ?> other = (RestPayload<?, ?, ?, ?>) obj;
             return Objects.equals(body, other.body)
                     && Objects.deepEquals(bodyBuffer, other.bodyBuffer)
                     && Objects.equals(headers, other.headers)

--- a/core/src/main/java/io/github/tcdl/msb/collector/Collector.java
+++ b/core/src/main/java/io/github/tcdl/msb/collector/Collector.java
@@ -7,7 +7,7 @@ import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.events.EventHandlers;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.support.Utils;
@@ -29,7 +29,7 @@ import static io.github.tcdl.msb.support.Utils.ifNull;
 /**
  * {@link Collector} is a component which collects responses and acknowledgements for sent requests.
  */
-public class Collector<T extends Payload> {
+public class Collector<T extends RestPayload> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Collector.class);
 

--- a/core/src/main/java/io/github/tcdl/msb/collector/Collector.java
+++ b/core/src/main/java/io/github/tcdl/msb/collector/Collector.java
@@ -7,7 +7,6 @@ import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.events.EventHandlers;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.support.Utils;
@@ -29,7 +28,7 @@ import static io.github.tcdl.msb.support.Utils.ifNull;
 /**
  * {@link Collector} is a component which collects responses and acknowledgements for sent requests.
  */
-public class Collector<T extends RestPayload> {
+public class Collector<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Collector.class);
 

--- a/core/src/main/java/io/github/tcdl/msb/events/EventHandlers.java
+++ b/core/src/main/java/io/github/tcdl/msb/events/EventHandlers.java
@@ -4,12 +4,11 @@ import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * {@link EventHandlers} is a component that allows to register custom event handlers for {@link Requester} specific events.
  */
-public class EventHandlers<T extends RestPayload> {
+public class EventHandlers<T> {
 
     private Callback<Acknowledge> onAcknowledge = acknowledge -> {};
     private Callback<T> onResponse = response -> {};

--- a/core/src/main/java/io/github/tcdl/msb/events/EventHandlers.java
+++ b/core/src/main/java/io/github/tcdl/msb/events/EventHandlers.java
@@ -4,12 +4,12 @@ import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
 /**
  * {@link EventHandlers} is a component that allows to register custom event handlers for {@link Requester} specific events.
  */
-public class EventHandlers<T extends Payload> {
+public class EventHandlers<T extends RestPayload> {
 
     private Callback<Acknowledge> onAcknowledge = acknowledge -> {};
     private Callback<T> onResponse = response -> {};

--- a/core/src/main/java/io/github/tcdl/msb/impl/NoopResponderImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/NoopResponderImpl.java
@@ -2,7 +2,7 @@ package io.github.tcdl.msb.impl;
 
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +26,7 @@ public class NoopResponderImpl implements Responder {
 
     /** {@inheritDoc} */
     @Override
-    public void send(Payload<?, ?, ?, ?> responsePayload) {
+    public void send(RestPayload<?, ?, ?, ?> responsePayload) {
         LOG.error("Cannot send response because response topic is unknown. Incoming message: {}", originalMessage);
     }
 

--- a/core/src/main/java/io/github/tcdl/msb/impl/NoopResponderImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/NoopResponderImpl.java
@@ -2,7 +2,6 @@ package io.github.tcdl.msb.impl;
 
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +25,7 @@ public class NoopResponderImpl implements Responder {
 
     /** {@inheritDoc} */
     @Override
-    public void send(RestPayload<?, ?, ?, ?> responsePayload) {
+    public void send(Object responsePayload) {
         LOG.error("Cannot send response because response topic is unknown. Incoming message: {}", originalMessage);
     }
 

--- a/core/src/main/java/io/github/tcdl/msb/impl/ObjectFactoryImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ObjectFactoryImpl.java
@@ -8,7 +8,7 @@ import io.github.tcdl.msb.api.PayloadConverter;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.ResponderServer;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
 import io.github.tcdl.msb.monitor.aggregator.DefaultChannelMonitorAggregator;
@@ -37,7 +37,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
     }
 
     @Override
-    public <T extends Payload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference) {
+    public <T extends RestPayload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference) {
         return RequesterImpl.create(namespace, requestOptions, msbContext, payloadTypeReference);
     }
 
@@ -45,7 +45,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
      * {@inheritDoc}
      */
     @Override
-    public <T extends Payload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    public <T extends RestPayload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference) {
         return ResponderServerImpl.create(namespace, messageTemplate, msbContext, requestHandler, payloadTypeReference);
     }

--- a/core/src/main/java/io/github/tcdl/msb/impl/ObjectFactoryImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ObjectFactoryImpl.java
@@ -8,7 +8,6 @@ import io.github.tcdl.msb.api.PayloadConverter;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.ResponderServer;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
 import io.github.tcdl.msb.monitor.aggregator.DefaultChannelMonitorAggregator;
@@ -45,7 +44,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
      * {@inheritDoc}
      */
     @Override
-    public <T> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    public <T> ResponderServer createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference) {
         return ResponderServerImpl.create(namespace, messageTemplate, msbContext, requestHandler, payloadTypeReference);
     }

--- a/core/src/main/java/io/github/tcdl/msb/impl/ObjectFactoryImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ObjectFactoryImpl.java
@@ -37,7 +37,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
     }
 
     @Override
-    public <T extends RestPayload> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference) {
+    public <T> Requester<T> createRequester(String namespace, RequestOptions requestOptions, TypeReference<T> payloadTypeReference) {
         return RequesterImpl.create(namespace, requestOptions, msbContext, payloadTypeReference);
     }
 
@@ -45,7 +45,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
      * {@inheritDoc}
      */
     @Override
-    public <T extends RestPayload> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
+    public <T> ResponderServer<T> createResponderServer(String namespace, MessageTemplate messageTemplate,
             ResponderServer.RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference) {
         return ResponderServerImpl.create(namespace, messageTemplate, msbContext, requestHandler, payloadTypeReference);
     }

--- a/core/src/main/java/io/github/tcdl/msb/impl/RequesterImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/RequesterImpl.java
@@ -8,7 +8,7 @@ import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.collector.Collector;
 import io.github.tcdl.msb.events.EventHandlers;
 import io.github.tcdl.msb.message.MessageFactory;
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.Validate;
  *
  * @see Requester
  */
-public class RequesterImpl<T extends Payload> implements Requester<T> {
+public class RequesterImpl<T extends RestPayload> implements Requester<T> {
 
     private RequestOptions requestOptions;
     private MsbContextImpl context;
@@ -39,7 +39,7 @@ public class RequesterImpl<T extends Payload> implements Requester<T> {
      * @param context        shared by all Requester instances
      * @return instance of a requester
      */
-    static <T extends  Payload> RequesterImpl<T> create(String namespace, RequestOptions requestOptions, MsbContextImpl context, TypeReference<T> payloadTypeReference) {
+    static <T extends RestPayload> RequesterImpl<T> create(String namespace, RequestOptions requestOptions, MsbContextImpl context, TypeReference<T> payloadTypeReference) {
         return new RequesterImpl<>(namespace, requestOptions, context, payloadTypeReference);
     }
 
@@ -61,7 +61,7 @@ public class RequesterImpl<T extends Payload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(Payload<?, ?, ?, ?> requestPayload) {
+    public void publish(RestPayload<?, ?, ?, ?> requestPayload) {
         publish(requestPayload, null, null);
     }
 
@@ -69,7 +69,7 @@ public class RequesterImpl<T extends Payload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(Payload<?, ?, ?, ?> requestPayload, String tag) {
+    public void publish(RestPayload<?, ?, ?, ?> requestPayload, String tag) {
         publish(requestPayload, null, tag);
     }
 
@@ -77,7 +77,7 @@ public class RequesterImpl<T extends Payload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(Payload<?, ?, ?, ?> requestPayload, Message originalMessage) {
+    public void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage) {
         publish(requestPayload, originalMessage, null);
     }
 
@@ -85,7 +85,7 @@ public class RequesterImpl<T extends Payload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(Payload<?, ?, ?, ?> requestPayload, Message originalMessage, String tag) {
+    public void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage, String tag) {
         MessageTemplate messageTemplate = MessageTemplate.copyOf(requestOptions.getMessageTemplate());
         if (tag != null) {
             messageTemplate.addTag(tag);

--- a/core/src/main/java/io/github/tcdl/msb/impl/RequesterImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/RequesterImpl.java
@@ -8,7 +8,6 @@ import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.collector.Collector;
 import io.github.tcdl.msb.events.EventHandlers;
 import io.github.tcdl.msb.message.MessageFactory;
@@ -21,7 +20,7 @@ import org.apache.commons.lang3.Validate;
  *
  * @see Requester
  */
-public class RequesterImpl<T extends RestPayload> implements Requester<T> {
+public class RequesterImpl<T> implements Requester<T> {
 
     private RequestOptions requestOptions;
     private MsbContextImpl context;
@@ -39,7 +38,7 @@ public class RequesterImpl<T extends RestPayload> implements Requester<T> {
      * @param context        shared by all Requester instances
      * @return instance of a requester
      */
-    static <T extends RestPayload> RequesterImpl<T> create(String namespace, RequestOptions requestOptions, MsbContextImpl context, TypeReference<T> payloadTypeReference) {
+    static <T> RequesterImpl<T> create(String namespace, RequestOptions requestOptions, MsbContextImpl context, TypeReference<T> payloadTypeReference) {
         return new RequesterImpl<>(namespace, requestOptions, context, payloadTypeReference);
     }
 
@@ -61,7 +60,7 @@ public class RequesterImpl<T extends RestPayload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(RestPayload<?, ?, ?, ?> requestPayload) {
+    public void publish(Object requestPayload) {
         publish(requestPayload, null, null);
     }
 
@@ -69,7 +68,7 @@ public class RequesterImpl<T extends RestPayload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(RestPayload<?, ?, ?, ?> requestPayload, String tag) {
+    public void publish(Object requestPayload, String tag) {
         publish(requestPayload, null, tag);
     }
 
@@ -77,7 +76,7 @@ public class RequesterImpl<T extends RestPayload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage) {
+    public void publish(Object requestPayload, Message originalMessage) {
         publish(requestPayload, originalMessage, null);
     }
 
@@ -85,7 +84,7 @@ public class RequesterImpl<T extends RestPayload> implements Requester<T> {
      * {@inheritDoc}
      */
     @Override
-    public void publish(RestPayload<?, ?, ?, ?> requestPayload, Message originalMessage, String tag) {
+    public void publish(Object requestPayload, Message originalMessage, String tag) {
         MessageTemplate messageTemplate = MessageTemplate.copyOf(requestOptions.getMessageTemplate());
         if (tag != null) {
             messageTemplate.addTag(tag);

--- a/core/src/main/java/io/github/tcdl/msb/impl/ResponderImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ResponderImpl.java
@@ -1,18 +1,17 @@
 package io.github.tcdl.msb.impl;
 
-import static io.github.tcdl.msb.api.message.Acknowledge.Builder;
 import io.github.tcdl.msb.ChannelManager;
 import io.github.tcdl.msb.Producer;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.message.MessageFactory;
 import io.github.tcdl.msb.support.Utils;
-
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static io.github.tcdl.msb.api.message.Acknowledge.Builder;
 
 public class ResponderImpl implements Responder {
 
@@ -51,7 +50,7 @@ public class ResponderImpl implements Responder {
      * {@inheritDoc}
      */
     @Override
-    public void send(RestPayload<?, ?, ?, ?> responsePayload) {
+    public void send(Object responsePayload) {
         Builder ackBuilder = this.messageFactory.createAckBuilder();
         ackBuilder.withResponderId(responderId);
         ackBuilder.withResponsesRemaining(-1);

--- a/core/src/main/java/io/github/tcdl/msb/impl/ResponderImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ResponderImpl.java
@@ -6,7 +6,7 @@ import io.github.tcdl.msb.Producer;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.message.MessageFactory;
 import io.github.tcdl.msb.support.Utils;
 
@@ -51,7 +51,7 @@ public class ResponderImpl implements Responder {
      * {@inheritDoc}
      */
     @Override
-    public void send(Payload<?, ?, ?, ?> responsePayload) {
+    public void send(RestPayload<?, ?, ?, ?> responsePayload) {
         Builder ackBuilder = this.messageFactory.createAckBuilder();
         ackBuilder.withResponderId(responderId);
         ackBuilder.withResponsesRemaining(-1);

--- a/core/src/main/java/io/github/tcdl/msb/impl/ResponderServerImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ResponderServerImpl.java
@@ -8,13 +8,13 @@ import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.ResponderServer;
 import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.support.Utils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ResponderServerImpl<T extends Payload> implements ResponderServer<T> {
+public class ResponderServerImpl<T extends RestPayload> implements ResponderServer<T> {
     private static final Logger LOG = LoggerFactory.getLogger(ResponderServerImpl.class);
 
     private String namespace;
@@ -37,7 +37,7 @@ public class ResponderServerImpl<T extends Payload> implements ResponderServer<T
     /**
      * {@link io.github.tcdl.msb.api.ObjectFactory#createResponderServer(String, MessageTemplate, RequestHandler, Class)}
      */
-    static <T extends Payload> ResponderServerImpl<T> create(String namespace,  MessageTemplate messageTemplate, MsbContextImpl msbContext,
+    static <T extends RestPayload> ResponderServerImpl<T> create(String namespace,  MessageTemplate messageTemplate, MsbContextImpl msbContext,
             RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference) {
         return new ResponderServerImpl<>(namespace, messageTemplate, msbContext, requestHandler, payloadTypeReference);
     }
@@ -93,7 +93,7 @@ public class ResponderServerImpl<T extends Payload> implements ResponderServer<T
     private void errorHandler(Responder responder, Exception exception, int errorStatusCode) {
         Message originalMessage = responder.getOriginalMessage();
         LOG.error("[{}] Error while processing message with id: [{}]", namespace, originalMessage.getId(), exception);
-        Payload responsePayload = new Payload.Builder()
+        RestPayload responsePayload = new RestPayload.Builder()
                 .withStatusCode(errorStatusCode)
                 .withStatusMessage(exception.getMessage())
                 .build();

--- a/core/src/main/java/io/github/tcdl/msb/impl/ResponderServerImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ResponderServerImpl.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ResponderServerImpl<T extends RestPayload> implements ResponderServer<T> {
+public class ResponderServerImpl<T> implements ResponderServer<T> {
     private static final Logger LOG = LoggerFactory.getLogger(ResponderServerImpl.class);
 
     private String namespace;
@@ -37,7 +37,7 @@ public class ResponderServerImpl<T extends RestPayload> implements ResponderServ
     /**
      * {@link io.github.tcdl.msb.api.ObjectFactory#createResponderServer(String, MessageTemplate, RequestHandler, Class)}
      */
-    static <T extends RestPayload> ResponderServerImpl<T> create(String namespace,  MessageTemplate messageTemplate, MsbContextImpl msbContext,
+    static <T> ResponderServerImpl<T> create(String namespace,  MessageTemplate messageTemplate, MsbContextImpl msbContext,
             RequestHandler<T> requestHandler, TypeReference<T> payloadTypeReference) {
         return new ResponderServerImpl<>(namespace, messageTemplate, msbContext, requestHandler, payloadTypeReference);
     }

--- a/core/src/main/java/io/github/tcdl/msb/impl/ResponderServerImpl.java
+++ b/core/src/main/java/io/github/tcdl/msb/impl/ResponderServerImpl.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ResponderServerImpl<T> implements ResponderServer<T> {
+public class ResponderServerImpl<T> implements ResponderServer {
     private static final Logger LOG = LoggerFactory.getLogger(ResponderServerImpl.class);
 
     private String namespace;

--- a/core/src/main/java/io/github/tcdl/msb/message/MessageFactory.java
+++ b/core/src/main/java/io/github/tcdl/msb/message/MessageFactory.java
@@ -8,7 +8,7 @@ import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.MetaMessage;
 import io.github.tcdl.msb.api.message.MetaMessage.Builder;
 import io.github.tcdl.msb.api.message.Topics;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.config.ServiceDetails;
 import io.github.tcdl.msb.support.Utils;
 import org.apache.commons.lang3.Validate;
@@ -33,20 +33,20 @@ public class MessageFactory {
         this.payloadMapper = payloadMapper;
     }
 
-    public Message createRequestMessage(Message.Builder messageBuilder, Payload payload) {
+    public Message createRequestMessage(Message.Builder messageBuilder, RestPayload payload) {
         JsonNode convertedPayload = Utils.convert(payload, JsonNode.class, payloadMapper);
         messageBuilder.withPayload(convertedPayload);
         return messageBuilder.build();
     }
 
-    public Message createResponseMessage(Message.Builder messageBuilder, Acknowledge ack, Payload<?, ?, ?, ?> payload) {
+    public Message createResponseMessage(Message.Builder messageBuilder, Acknowledge ack, RestPayload<?, ?, ?, ?> payload) {
         JsonNode convertedPayload = Utils.convert(payload, JsonNode.class, payloadMapper);
         messageBuilder.withPayload(convertedPayload);
         messageBuilder.withAck(ack);
         return messageBuilder.build();
     }
 
-    public Message createBroadcastMessage(Message.Builder messageBuilder, Payload payload) {
+    public Message createBroadcastMessage(Message.Builder messageBuilder, RestPayload payload) {
         return createRequestMessage(messageBuilder, payload);
     }
 

--- a/core/src/main/java/io/github/tcdl/msb/message/MessageFactory.java
+++ b/core/src/main/java/io/github/tcdl/msb/message/MessageFactory.java
@@ -33,13 +33,13 @@ public class MessageFactory {
         this.payloadMapper = payloadMapper;
     }
 
-    public Message createRequestMessage(Message.Builder messageBuilder, RestPayload payload) {
+    public Message createRequestMessage(Message.Builder messageBuilder, Object payload) {
         JsonNode convertedPayload = Utils.convert(payload, JsonNode.class, payloadMapper);
         messageBuilder.withPayload(convertedPayload);
         return messageBuilder.build();
     }
 
-    public Message createResponseMessage(Message.Builder messageBuilder, Acknowledge ack, RestPayload<?, ?, ?, ?> payload) {
+    public Message createResponseMessage(Message.Builder messageBuilder, Acknowledge ack, Object payload) {
         JsonNode convertedPayload = Utils.convert(payload, JsonNode.class, payloadMapper);
         messageBuilder.withPayload(convertedPayload);
         messageBuilder.withAck(ack);

--- a/core/src/main/java/io/github/tcdl/msb/monitor/agent/DefaultChannelMonitorAgent.java
+++ b/core/src/main/java/io/github/tcdl/msb/monitor/agent/DefaultChannelMonitorAgent.java
@@ -3,12 +3,12 @@ package io.github.tcdl.msb.monitor.agent;
 import io.github.tcdl.msb.ChannelManager;
 import io.github.tcdl.msb.Producer;
 import io.github.tcdl.msb.api.Responder;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.impl.ResponderImpl;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.message.MessageFactory;
-import io.github.tcdl.msb.api.message.payload.Payload;
 import io.github.tcdl.msb.support.Utils;
 
 import java.time.Clock;
@@ -59,7 +59,7 @@ public class DefaultChannelMonitorAgent implements ChannelMonitorAgent {
         channelManager.subscribe(Utils.TOPIC_HEARTBEAT, // Launch listener for heartbeat topic
                 message -> {
                         Responder responder = new ResponderImpl(null, message, msbContext);
-                        Payload payload = new Payload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
+                        RestPayload payload = new RestPayload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
                                 .withBody(topicInfoMap)
                                 .build();
                         responder.send(payload);
@@ -140,7 +140,7 @@ public class DefaultChannelMonitorAgent implements ChannelMonitorAgent {
      * Makes broadcast of the current statistics.
      */
     private void doAnnounce() {
-        Payload payload = new Payload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
+        RestPayload payload = new RestPayload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
                 .withBody(topicInfoMap)
                 .build();
 

--- a/core/src/main/java/io/github/tcdl/msb/monitor/aggregator/DefaultChannelMonitorAggregator.java
+++ b/core/src/main/java/io/github/tcdl/msb/monitor/aggregator/DefaultChannelMonitorAggregator.java
@@ -16,7 +16,7 @@ import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.MetaMessage;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.AggregatorTopicStats;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
@@ -107,8 +107,8 @@ public class DefaultChannelMonitorAggregator implements ChannelMonitorAggregator
         }
 
         try {
-            Payload<?, ?, ?, Map<String, AgentTopicStats>> payload = Utils
-                    .convert(rawPayload, new TypeReference<Payload<Object, Object, Object, Map<String, AgentTopicStats>>>() {
+            RestPayload<?, ?, ?, Map<String, AgentTopicStats>> payload = Utils
+                    .convert(rawPayload, new TypeReference<RestPayload<Object, Object, Object, Map<String, AgentTopicStats>>>() {
                     }, messageMapper);
             MetaMessage meta = message.getMeta();
             ServiceDetails serviceDetails = meta.getServiceDetails();

--- a/core/src/main/java/io/github/tcdl/msb/monitor/aggregator/HeartbeatTask.java
+++ b/core/src/main/java/io/github/tcdl/msb/monitor/aggregator/HeartbeatTask.java
@@ -4,7 +4,7 @@ import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.support.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,7 @@ public class HeartbeatTask implements Runnable {
                     .withWaitForResponses(-1)
                     .build();
 
-            Payload emptyPayload = new Payload.Builder().build();
+            RestPayload emptyPayload = new RestPayload.Builder().build();
 
             List<Message> messages = new LinkedList<>();
             objectFactory.createRequester(Utils.TOPIC_HEARTBEAT, requestOptions)

--- a/core/src/test/java/io/github/tcdl/msb/ProducerTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/ProducerTest.java
@@ -10,7 +10,7 @@ import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.MetaMessage;
 import io.github.tcdl.msb.api.message.Topics;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.config.MsbConfig;
 import io.github.tcdl.msb.support.TestUtils;
 import io.github.tcdl.msb.support.Utils;
@@ -111,7 +111,7 @@ public class ProducerTest {
         Topics topic = new Topics(topicTo, topicTo + ":response:" + msbConf.getServiceDetails().getInstanceId());
         Map<String, String> body = new HashMap<>();
         body.put("body", "{\\\"x\\\" : 3} garbage");
-        Payload<?, ?, ?, Map<String, String>> payload = new Payload.Builder<Object, Object, Object, Map<String, String>>()
+        RestPayload<?, ?, ?, Map<String, String>> payload = new RestPayload.Builder<Object, Object, Object, Map<String, String>>()
                 .withBody(body)
                 .build();
         JsonNode payloadNode = Utils.convert(payload, JsonNode.class, payloadMapper);

--- a/core/src/test/java/io/github/tcdl/msb/api/ChannelMonitorIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/ChannelMonitorIT.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.github.tcdl.msb.adapters.mock.MockAdapter;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
 import io.github.tcdl.msb.impl.MsbContextImpl;
@@ -96,7 +96,7 @@ public class ChannelMonitorIT {
         Map<String, AgentTopicStats> topicInfoMap = new HashMap<>();
         topicInfoMap.put(TOPIC_NAME, new AgentTopicStats(true, false, LAST_PRODUCED_TIME, LAST_CONSUMED_TIME));
 
-        Payload payload = new Payload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
+        RestPayload payload = new RestPayload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
                 .withBody(topicInfoMap)
                 .build();
 
@@ -129,7 +129,7 @@ public class ChannelMonitorIT {
         Map<String, AgentTopicStats> topicInfoMap = new HashMap<>();
         topicInfoMap.put(TOPIC_NAME, new AgentTopicStats(true, false, LAST_PRODUCED_TIME, LAST_CONSUMED_TIME));
 
-        Payload payload = new Payload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
+        RestPayload payload = new RestPayload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
                 .withBody(topicInfoMap)
                 .build();
 

--- a/core/src/test/java/io/github/tcdl/msb/api/RequesterIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/RequesterIT.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Base64;
 import io.github.tcdl.msb.adapters.mock.MockAdapter;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.support.TestUtils;
 import org.junit.Before;
@@ -30,8 +30,8 @@ public class RequesterIT {
 
     @Test
     public void testRequestMessage() throws Exception {
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -41,8 +41,8 @@ public class RequesterIT {
     @Test
     public void testRequestMessageWithBodyBufferBase64Encoded() throws Exception {
         byte[] bytesToSend = new byte[] { 1, 2 };
-        Payload requestPayload = TestUtils.createSimpleRequestPayloadWithBodyBuffer(bytesToSend);
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayloadWithBodyBuffer(bytesToSend);
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -55,8 +55,8 @@ public class RequesterIT {
     @Test
     public void testRequestMessageWithDynamicTag() throws Exception {
         String dynamicTag = "dynamic-tag";
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload, dynamicTag);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -69,8 +69,8 @@ public class RequesterIT {
         String dynamicTag = "dynamic-tag";
         String dynamicTagOriginal = "dynamic-tag-original";
         Message originalMessage = TestUtils.createSimpleRequestMessageWithTags(NAMESPACE, dynamicTagOriginal);
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload, originalMessage, dynamicTag);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -83,8 +83,8 @@ public class RequesterIT {
         String dynamicTag = "dynamic-tag";
         String dynamicTagOriginal = "dynamic-tag-original";
         Message originalMessage = TestUtils.createSimpleRequestMessageWithTags(NAMESPACE, dynamicTagOriginal, STATIC_TAG);
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload, originalMessage, dynamicTag);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);

--- a/core/src/test/java/io/github/tcdl/msb/api/RequesterIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/RequesterIT.java
@@ -31,7 +31,7 @@ public class RequesterIT {
     @Test
     public void testRequestMessage() throws Exception {
         RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -42,7 +42,7 @@ public class RequesterIT {
     public void testRequestMessageWithBodyBufferBase64Encoded() throws Exception {
         byte[] bytesToSend = new byte[] { 1, 2 };
         RestPayload requestPayload = TestUtils.createSimpleRequestPayloadWithBodyBuffer(bytesToSend);
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -56,7 +56,7 @@ public class RequesterIT {
     public void testRequestMessageWithDynamicTag() throws Exception {
         String dynamicTag = "dynamic-tag";
         RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload, dynamicTag);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -70,7 +70,7 @@ public class RequesterIT {
         String dynamicTagOriginal = "dynamic-tag-original";
         Message originalMessage = TestUtils.createSimpleRequestMessageWithTags(NAMESPACE, dynamicTagOriginal);
         RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload, originalMessage, dynamicTag);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);
@@ -84,7 +84,7 @@ public class RequesterIT {
         String dynamicTagOriginal = "dynamic-tag-original";
         Message originalMessage = TestUtils.createSimpleRequestMessageWithTags(NAMESPACE, dynamicTagOriginal, STATIC_TAG);
         RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(NAMESPACE, requestOptions);
         requester.publish(requestPayload, originalMessage, dynamicTag);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(NAMESPACE);

--- a/core/src/test/java/io/github/tcdl/msb/api/RequesterResponderIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/RequesterResponderIT.java
@@ -1,5 +1,6 @@
 package io.github.tcdl.msb.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.tcdl.msb.adapters.mock.MockAdapter;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.payload.RestPayload;
@@ -50,7 +51,7 @@ public class RequesterResponderIT {
         CountDownLatch requestReceived = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
         RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
 
         msbContext.getObjectFactory().createResponderServer(namespace, requestOptions.getMessageTemplate(), (request, response) -> {
@@ -70,7 +71,7 @@ public class RequesterResponderIT {
         CountDownLatch requestReceived = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
         Body sentBody = new Body("test:requester-responder-test-body");
         RestPayload<Object, Object, Object, Body> requestPayload = new RestPayload.Builder<Object, Object, Object, Body>()
                 .withBody(sentBody)
@@ -96,7 +97,7 @@ public class RequesterResponderIT {
         CountDownLatch requestReceived = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
         Body sentBody = new Body("test:requester-responder-test-body");
         RestPayload<Object, Object, Object, Body> requestPayload = new RestPayload.Builder<Object, Object, Object, Body>()
                 .withBody(sentBody)
@@ -107,7 +108,7 @@ public class RequesterResponderIT {
             PayloadConverter payloadConverter = msbContext.getObjectFactory().getPayloadConverter();
             receivedBody.setBody(payloadConverter.getAs(request.getBody(), Body.class).getBody());
             requestReceived.countDown();
-        })
+        }, RestPayload.class)
         .listen();
 
         requester.publish(requestPayload);
@@ -263,7 +264,7 @@ public class RequesterResponderIT {
         serverOneMsbContext.getObjectFactory().createResponderServer(namespace1, responderServerOneMessageOptions, (request, response) -> {
 
             //Create and send request message, wait for ack
-            Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace2, requestAwaitAckMessageOptions);
+            Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(namespace2, requestAwaitAckMessageOptions);
             RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
             requester.onAcknowledge((Acknowledge a) -> ackReceived.countDown());
             requester.publish(requestPayload);
@@ -363,7 +364,7 @@ public class RequesterResponderIT {
         CountDownLatch endConversation2 = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptionsWaitResponse).onEnd(arg -> endConversation1.countDown());
+        Requester<JsonNode> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptionsWaitResponse).onEnd(arg -> endConversation1.countDown());
         requester.publish(TestUtils.createSimpleRequestPayload());
         assertTrue("Message was not received", endConversation1.await(MESSAGE_TRANSMISSION_TIME, TimeUnit.MILLISECONDS));
 

--- a/core/src/test/java/io/github/tcdl/msb/api/RequesterResponderIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/RequesterResponderIT.java
@@ -2,7 +2,7 @@ package io.github.tcdl.msb.api;
 
 import io.github.tcdl.msb.adapters.mock.MockAdapter;
 import io.github.tcdl.msb.api.message.Acknowledge;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.message.payload.Body;
 import io.github.tcdl.msb.message.payload.MyPayload;
@@ -50,8 +50,8 @@ public class RequesterResponderIT {
         CountDownLatch requestReceived = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
 
         msbContext.getObjectFactory().createResponderServer(namespace, requestOptions.getMessageTemplate(), (request, response) -> {
             requestReceived.countDown();
@@ -70,9 +70,9 @@ public class RequesterResponderIT {
         CountDownLatch requestReceived = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
         Body sentBody = new Body("test:requester-responder-test-body");
-        Payload<Object, Object, Object, Body> requestPayload = new Payload.Builder<Object, Object, Object, Body>()
+        RestPayload<Object, Object, Object, Body> requestPayload = new RestPayload.Builder<Object, Object, Object, Body>()
                 .withBody(sentBody)
                 .build();
 
@@ -96,9 +96,9 @@ public class RequesterResponderIT {
         CountDownLatch requestReceived = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptions);
         Body sentBody = new Body("test:requester-responder-test-body");
-        Payload<Object, Object, Object, Body> requestPayload = new Payload.Builder<Object, Object, Object, Body>()
+        RestPayload<Object, Object, Object, Body> requestPayload = new RestPayload.Builder<Object, Object, Object, Body>()
                 .withBody(sentBody)
                 .build();
 
@@ -131,7 +131,7 @@ public class RequesterResponderIT {
         List<Acknowledge> receivedResponseAcks = new LinkedList<>();
 
         //Create and send request message directly to broker, wait for ack  
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
         msbContext.getObjectFactory().createRequester(namespace, requestOptions).
                 onAcknowledge((Acknowledge ack) -> {
                     receivedResponseAcks.add(ack);
@@ -164,12 +164,12 @@ public class RequesterResponderIT {
         CountDownLatch respSend = new CountDownLatch(1);
         CountDownLatch respReceived = new CountDownLatch(1);
 
-        ConcurrentLinkedQueue<Payload> sentResponses = new ConcurrentLinkedQueue<>();
-        ConcurrentLinkedQueue<Payload> receivedResponses = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<RestPayload> sentResponses = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<RestPayload> receivedResponses = new ConcurrentLinkedQueue<>();
 
         //Create and send request message directly to broker, wait for response
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
-        msbContext.getObjectFactory().createRequester(namespace, requestOptions, Payload.class)
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
+        msbContext.getObjectFactory().createRequester(namespace, requestOptions, RestPayload.class)
                 .onResponse(payload -> {
                     receivedResponses.add(payload);
                     respReceived.countDown();
@@ -181,7 +181,7 @@ public class RequesterResponderIT {
         Map<String, String> bodyMap = new HashMap<>();
         bodyMap.put("body", "payload from test testResponderAnswerWithResponseRequesterReceiveResponse");
         serverMsbContext.getObjectFactory().createResponderServer(namespace, messageTemplate, (request, response) -> {
-            Payload payload = new Payload.Builder<Object, Object, Object, Map<String, String>>()
+            RestPayload payload = new RestPayload.Builder<Object, Object, Object, Map<String, String>>()
                     .withBody(bodyMap)
                     .withStatusCode(3333)
                     .build();
@@ -209,11 +209,11 @@ public class RequesterResponderIT {
         CountDownLatch respSend = new CountDownLatch(1);
         CountDownLatch respReceived = new CountDownLatch(1);
 
-        ConcurrentLinkedQueue<Payload> sentResponses = new ConcurrentLinkedQueue<>();
-        ConcurrentLinkedQueue<Payload> receivedResponses = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<RestPayload> sentResponses = new ConcurrentLinkedQueue<>();
+        ConcurrentLinkedQueue<RestPayload> receivedResponses = new ConcurrentLinkedQueue<>();
 
         //Create and send request message directly to broker, wait for response
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
         Body receivedBody = new Body();
         msbContext.getObjectFactory().createRequester(namespace, requestOptions, MyPayload.class)
                 .onResponse(payload -> {
@@ -226,7 +226,7 @@ public class RequesterResponderIT {
         //listen for message and send response
         MsbContextImpl serverMsbContext = TestUtils.createSimpleMsbContext();
         Body responseBody = new Body("payload from test testResponderAnswerWithResponseRequesterReceiveResponse");
-        Payload responsePayload = new Payload.Builder<Object, Object, Object, Body>()
+        RestPayload responsePayload = new RestPayload.Builder<Object, Object, Object, Body>()
                 .withBody(responseBody)
                 .build();
 
@@ -263,8 +263,8 @@ public class RequesterResponderIT {
         serverOneMsbContext.getObjectFactory().createResponderServer(namespace1, responderServerOneMessageOptions, (request, response) -> {
 
             //Create and send request message, wait for ack
-            Requester<Payload> requester = msbContext.getObjectFactory().createRequester(namespace2, requestAwaitAckMessageOptions);
-            Payload requestPayload = TestUtils.createSimpleRequestPayload();
+            Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace2, requestAwaitAckMessageOptions);
+            RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
             requester.onAcknowledge((Acknowledge a) -> ackReceived.countDown());
             requester.publish(requestPayload);
         })
@@ -301,7 +301,7 @@ public class RequesterResponderIT {
         Set<Acknowledge> receivedResponseAcks = new HashSet<>();
 
         //Create and send request messages directly to broker, wait for ack
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
 
         final AtomicInteger messagesToSend = new AtomicInteger(requestsToSendDuringTest);
         Thread publishingThread = new Thread(() -> {
@@ -346,7 +346,7 @@ public class RequesterResponderIT {
 
         Thread serverListenThread = new Thread(() -> {
             msbContext.getObjectFactory().createResponderServer(namespace, requestOptionsWaitResponse.getMessageTemplate(), (request, response) -> {
-                Payload payload = new Payload.Builder<Object, Object, Object, String>()
+                RestPayload payload = new RestPayload.Builder<Object, Object, Object, String>()
                         .withBody(new HashMap<String, String>()
                                 .put("body", "payload from test : testRequestMessageCollectorUnsubscribeAfterResponsesAndSubscribeAgain"))
                         .withStatusCode(4444)
@@ -363,7 +363,7 @@ public class RequesterResponderIT {
         CountDownLatch endConversation2 = new CountDownLatch(1);
 
         //Create and send request message
-        Requester<Payload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptionsWaitResponse).onEnd(arg -> endConversation1.countDown());
+        Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester(namespace, requestOptionsWaitResponse).onEnd(arg -> endConversation1.countDown());
         requester.publish(TestUtils.createSimpleRequestPayload());
         assertTrue("Message was not received", endConversation1.await(MESSAGE_TRANSMISSION_TIME, TimeUnit.MILLISECONDS));
 

--- a/core/src/test/java/io/github/tcdl/msb/api/ResponderIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/ResponderIT.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.tcdl.msb.adapters.mock.MockAdapter;
 import io.github.tcdl.msb.api.exception.JsonSchemaValidationException;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.impl.MsbContextImpl;
 import io.github.tcdl.msb.impl.ResponderImpl;
 import io.github.tcdl.msb.support.JsonValidator;
@@ -90,7 +90,7 @@ public class ResponderIT {
         Message originalMessage = TestUtils.createSimpleRequestMessage(namespace);
 
         Responder responder = new ResponderImpl(messageOptions, originalMessage, msbContext);
-        Payload responsePayload = TestUtils.createSimpleResponsePayload();
+        RestPayload responsePayload = TestUtils.createSimpleResponsePayload();
         responder.send(responsePayload);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(originalMessage.getTopics().getResponse());
@@ -107,7 +107,7 @@ public class ResponderIT {
         Message originalMessage = TestUtils.createSimpleRequestMessageWithTags(namespace, dynamicTagOriginal);
 
         Responder responder = new ResponderImpl(messageOptions, originalMessage, msbContext);
-        Payload responsePayload = TestUtils.createSimpleResponsePayload();
+        RestPayload responsePayload = TestUtils.createSimpleResponsePayload();
         responder.send(responsePayload);
 
         String adapterJsonMessage = MockAdapter.pollJsonMessageForTopic(originalMessage.getTopics().getResponse());

--- a/core/src/test/java/io/github/tcdl/msb/api/message/payload/RestPayloadTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/message/payload/RestPayloadTest.java
@@ -1,12 +1,12 @@
 package io.github.tcdl.msb.api.message.payload;
 
 import static org.junit.Assert.*;
-import io.github.tcdl.msb.api.message.payload.Payload.Builder;
+import io.github.tcdl.msb.api.message.payload.RestPayload.Builder;
 
 import org.junit.Test;
 
 
-public class PayloadTest {
+public class RestPayloadTest {
     @Test
     public void testEquals() {
         Builder bob = payloadBuilder();
@@ -46,7 +46,7 @@ public class PayloadTest {
     }
 
     private Builder<String, String, String, String> payloadBuilder() {
-        return new Payload.Builder<String, String, String, String>()
+        return new RestPayload.Builder<String, String, String, String>()
             .withBody("some-body")
             .withBodyBuffer("some-body".getBytes())
             .withHeaders("headers")

--- a/core/src/test/java/io/github/tcdl/msb/collector/CollectorTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/collector/CollectorTest.java
@@ -7,7 +7,7 @@ import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.config.MsbConfig;
 import io.github.tcdl.msb.events.EventHandlers;
 import io.github.tcdl.msb.impl.MsbContextImpl;
@@ -57,7 +57,7 @@ public class CollectorTest {
     private ChannelManager channelManagerMock;
 
     @Mock
-    private EventHandlers<Payload> eventHandlers;
+    private EventHandlers<RestPayload> eventHandlers;
 
     @Mock
     private MsbConfig msbConfigurationsMock;
@@ -90,42 +90,42 @@ public class CollectorTest {
     @Test
     public void testGetWaitForResponsesConfigsReturnFalse() {
         when(requestOptionsMock.getWaitForResponses()).thenReturn(0);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         assertFalse("expect false if MessageOptions.waitForResponses equals 0", collector.isAwaitingResponses());
     }
 
     @Test
     public void testGetWaitForResponsesConfigsReturnFalseMinusCase() {
         when(requestOptionsMock.getWaitForResponses()).thenReturn(-10);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         assertFalse("expect false if MessageOptions.waitForResponses equals -10", collector.isAwaitingResponses());
     }
 
     @Test
     public void testGetWaitForResponsesConfigsReturnTrue() {
         when(requestOptionsMock.getWaitForResponses()).thenReturn(100);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         assertTrue("expect true if MessageOptions.waitForResponses equals 100", collector.isAwaitingResponses());
     }
 
     @Test
     public void testGetWaitForResponsesConfigsReturnTrueMinusOne() {
         when(requestOptionsMock.getWaitForResponses()).thenReturn(-1);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         assertTrue("expect true if MessageOptions.waitForResponses equals -1", collector.isAwaitingResponses());
     }
 
     @Test
     public void testIsAwaitingAcksConfigsNotSetAckTimeoutReturnFalse() {
         when(requestOptionsMock.getAckTimeout()).thenReturn(null);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         assertFalse("expect false if MessageOptions.ackTimeout null", collector.isAwaitingAcks());
     }
 
     @Test
     public void testIsAwaitingAcksReturnTrue() {
         when(requestOptionsMock.getAckTimeout()).thenReturn(200);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         assertTrue("expect true if MessageOptions.ackTimeout equals 200", collector.isAwaitingAcks());
     }
 
@@ -134,17 +134,17 @@ public class CollectorTest {
         String bodyText =  "some body";
         Message responseMessage = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
         @SuppressWarnings("unchecked")
-        Callback<Payload> onResponse = mock(Callback.class);
+        Callback<RestPayload> onResponse = mock(Callback.class);
         @SuppressWarnings("unchecked")
         Callback<Message> onRawResponse = mock(Callback.class);
         when(eventHandlers.onResponse()).thenReturn(onResponse);
         when(eventHandlers.onRawResponse()).thenReturn(onRawResponse);
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
 
         // method under test
         collector.handleMessage(responseMessage);
 
-        Payload<?, ?, ?, String> expectedPayload = new Payload.Builder<Object, Object, Object, String>()
+        RestPayload<?, ?, ?, String> expectedPayload = new RestPayload.Builder<Object, Object, Object, String>()
                 .withBody(bodyText)
                 .build();
         verify(onRawResponse).call(responseMessage);
@@ -159,16 +159,16 @@ public class CollectorTest {
         String bodyText = "some body";
         Message responseMessage = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
         @SuppressWarnings("unchecked")
-        Callback<Payload<?, ?, ?, Integer>> onResponse = mock(Callback.class);
+        Callback<RestPayload<?, ?, ?, Integer>> onResponse = mock(Callback.class);
         @SuppressWarnings("unchecked")
         Callback<Message> onRawResponse = mock(Callback.class);
 
         @SuppressWarnings("unchecked")
-        EventHandlers<Payload<?, ?, ?, Integer>> eventHandlers = mock(EventHandlers.class);
+        EventHandlers<RestPayload<?, ?, ?, Integer>> eventHandlers = mock(EventHandlers.class);
         when(eventHandlers.onResponse()).thenReturn(onResponse);
         when(eventHandlers.onRawResponse()).thenReturn(onRawResponse);
-        TypeReference<Payload<?, ?, ?, Integer>> payloadTypeReference = new TypeReference<Payload<?, ?, ?, Integer>>() {};
-        Collector<Payload<?, ?, ?, Integer>> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, payloadTypeReference);
+        TypeReference<RestPayload<?, ?, ?, Integer>> payloadTypeReference = new TypeReference<RestPayload<?, ?, ?, Integer>>() {};
+        Collector<RestPayload<?, ?, ?, Integer>> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, payloadTypeReference);
 
         // make sure that onRawResponse is called even if conversion of payload to custom type fails
         try {
@@ -184,7 +184,7 @@ public class CollectorTest {
     public void testHandleResponseReceivedAck() {
         Callback<Acknowledge> onAck = mock(Callback.class);
         when(eventHandlers.onAcknowledge()).thenReturn(onAck);
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
 
         collector.handleMessage(responseMessageWithAck);
 
@@ -198,7 +198,7 @@ public class CollectorTest {
     public void testHandleResponseEndEventNoResponsesRemaining() {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
 
         collector.handleMessage(responseMessageWithAck);
 
@@ -220,15 +220,15 @@ public class CollectorTest {
         when(requestOptionsMock.getResponseTimeout()).thenReturn(responseTimeout);
         when(requestOptionsMock.getWaitForResponses()).thenReturn(1);
 
-        Callback<Payload> onResponse = mock(Callback.class);
+        Callback<RestPayload> onResponse = mock(Callback.class);
         when(eventHandlers.onResponse()).thenReturn(onResponse);
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.handleMessage(responseMessage);
 
-        Payload<?, ?, ?, String> expectedPayload = new Payload.Builder<Object, Object, Object, String>()
+        RestPayload<?, ?, ?, String> expectedPayload = new RestPayload.Builder<Object, Object, Object, String>()
                 .withBody(bodyText)
                 .build();
         verify(onResponse).call(expectedPayload);
@@ -250,15 +250,15 @@ public class CollectorTest {
         when(requestOptionsMock.getResponseTimeout()).thenReturn(responseTimeout);
         when(requestOptionsMock.getWaitForResponses()).thenReturn(2);
 
-        Callback<Payload> onResponse = mock(Callback.class);
+        Callback<RestPayload> onResponse = mock(Callback.class);
         when(eventHandlers.onResponse()).thenReturn(onResponse);
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
-        Payload<?, ?, ?, String> expectedPayload = new Payload.Builder<Object, Object, Object, String>()
+        RestPayload<?, ?, ?, String> expectedPayload = new RestPayload.Builder<Object, Object, Object, String>()
                 .withBody(bodyText)
                 .build();
 
@@ -293,7 +293,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         //send payload response
@@ -321,7 +321,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         //send payload response
@@ -349,7 +349,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         //send payload response
@@ -372,7 +372,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         Acknowledge ack = new Acknowledge.Builder().withResponderId(Utils.generateId()).withResponsesRemaining(0).withTimeoutMs(timeoutMs).build();
@@ -398,7 +398,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         Acknowledge ack = new Acknowledge.Builder().withResponderId(Utils.generateId()).withResponsesRemaining(0).withTimeoutMs(timeoutMsInAck)
@@ -426,7 +426,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         Acknowledge ack = new Acknowledge.Builder().withResponderId(Utils.generateId()).withResponsesRemaining(responsesRemaining)
@@ -456,7 +456,7 @@ public class CollectorTest {
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         Acknowledge ackRespOne = new Acknowledge.Builder().withResponderId(Utils.generateId()).withResponsesRemaining(responsesRemainingResponderOne)
@@ -494,12 +494,12 @@ public class CollectorTest {
         when(requestOptionsMock.getResponseTimeout()).thenReturn(responseTimeout);
         when(requestOptionsMock.getWaitForResponses()).thenReturn(responsesRemaining);
 
-        Callback<Payload> onResponse = mock(Callback.class);
+        Callback<RestPayload> onResponse = mock(Callback.class);
         when(eventHandlers.onResponse()).thenReturn(onResponse);
         Callback<Void> onEnd = mock(Callback.class);
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
-        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector collector = new Collector(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         assertEquals(responsesRemaining, collector.getResponsesRemaining());
@@ -517,7 +517,7 @@ public class CollectorTest {
 
     @Test
     public void testListenForResponses() {
-        Collector<Payload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<Payload>() {});
+        Collector<RestPayload> collector = new Collector<>(TOPIC, originalMessage, requestOptionsMock, msbContext, eventHandlers, new TypeReference<RestPayload>() {});
         collector.listenForResponses();
 
         verify(collectorManagerMock).registerCollector(collector);

--- a/core/src/test/java/io/github/tcdl/msb/impl/RequesterImplTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/impl/RequesterImplTest.java
@@ -9,7 +9,7 @@ import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.collector.Collector;
 import io.github.tcdl.msb.events.EventHandlers;
 import io.github.tcdl.msb.support.TestUtils;
@@ -44,7 +44,7 @@ public class RequesterImplTest {
     private static final String NAMESPACE = "test:requester";
 
     @Mock
-    private EventHandlers<Payload> eventHandlerMock;
+    private EventHandlers<RestPayload> eventHandlerMock;
 
     @Mock
     private ChannelManager channelManagerMock;
@@ -60,7 +60,7 @@ public class RequesterImplTest {
 
     @Test
     public void testPublishNoWaitForResponses() throws Exception {
-        RequesterImpl<Payload> requester = initRequesterForResponsesWithTimeout(0);
+        RequesterImpl<RestPayload> requester = initRequesterForResponsesWithTimeout(0);
 
         requester.publish(TestUtils.createSimpleRequestPayload());
 
@@ -70,7 +70,7 @@ public class RequesterImplTest {
 
     @Test
     public void testPublishWaitForResponses() throws Exception {
-        RequesterImpl<Payload> requester = initRequesterForResponsesWithTimeout(1);
+        RequesterImpl<RestPayload> requester = initRequesterForResponsesWithTimeout(1);
 
         //doReturn(mock(CollectorManager.class)).when(collectorMock).findOrCreateCollectorManager(anyString());
 
@@ -83,9 +83,9 @@ public class RequesterImplTest {
     @Test
     public void testProducerPublishWithPayload() throws Exception {
         String bodyText = "Body text";
-        RequesterImpl<Payload> requester = initRequesterForResponsesWithTimeout(0);
+        RequesterImpl<RestPayload> requester = initRequesterForResponsesWithTimeout(0);
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-        Payload payload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload payload = TestUtils.createPayloadWithTextBody(bodyText);
 
         requester.publish(payload);
 
@@ -175,8 +175,8 @@ public class RequesterImplTest {
                 .withClock(Clock.systemDefaultZone())
                 .build();
 
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
-        Requester<Payload> requester = RequesterImpl.create(NAMESPACE, TestUtils.createSimpleRequestOptions(), msbContext, new TypeReference<Payload>() {});
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
+        Requester<RestPayload> requester = RequesterImpl.create(NAMESPACE, TestUtils.createSimpleRequestOptions(), msbContext, new TypeReference<RestPayload>() {});
         requester.publish(requestPayload);
         verify(producerMock).publish(messageArgumentCaptor.capture());
 
@@ -200,10 +200,10 @@ public class RequesterImplTest {
 
         String tag = "requester-tag";
         String dynamicTag = "dynamic-tag";
-        Payload requestPayload = TestUtils.createSimpleRequestPayload();
+        RestPayload requestPayload = TestUtils.createSimpleRequestPayload();
         RequestOptions requestOptions = TestUtils.createSimpleRequestOptionsWithTags(tag);
 
-        Requester<Payload> requester = RequesterImpl.create(NAMESPACE, requestOptions, msbContext, new TypeReference<Payload>() {});
+        Requester<RestPayload> requester = RequesterImpl.create(NAMESPACE, requestOptions, msbContext, new TypeReference<RestPayload>() {});
         requester.publish(requestPayload, dynamicTag);
         verify(producerMock).publish(messageArgumentCaptor.capture());
 
@@ -211,7 +211,7 @@ public class RequesterImplTest {
         assertArrayEquals(new String[]{tag, dynamicTag}, requestMessage.getTags().toArray());
     }
 
-    private RequesterImpl<Payload> initRequesterForResponsesWithTimeout(int numberOfResponses) throws Exception {
+    private RequesterImpl<RestPayload> initRequesterForResponsesWithTimeout(int numberOfResponses) throws Exception {
 
         MessageTemplate messageTemplateMock = mock(MessageTemplate.class);
 
@@ -224,10 +224,10 @@ public class RequesterImplTest {
                 .withChannelManager(channelManagerMock)
                 .build();
 
-        RequesterImpl<Payload> requester = spy(RequesterImpl.create(NAMESPACE, requestOptionsMock, msbContext, new TypeReference<Payload>() {}));
+        RequesterImpl<RestPayload> requester = spy(RequesterImpl.create(NAMESPACE, requestOptionsMock, msbContext, new TypeReference<RestPayload>() {}));
 
         collectorMock = spy(new Collector<>(NAMESPACE, TestUtils.createMsbRequestMessageNoPayload(NAMESPACE), requestOptionsMock, msbContext, eventHandlerMock,
-                new TypeReference<Payload>() {}));
+                new TypeReference<RestPayload>() {}));
 
         doReturn(collectorMock)
                 .when(requester)

--- a/core/src/test/java/io/github/tcdl/msb/impl/ResponderImplTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/impl/ResponderImplTest.java
@@ -5,7 +5,7 @@ import io.github.tcdl.msb.Producer;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.config.MsbConfig;
 import io.github.tcdl.msb.message.MessageFactory;
 import io.github.tcdl.msb.support.TestUtils;
@@ -36,7 +36,7 @@ public class ResponderImplTest {
     private MsbContextImpl msbContextSpy;
     private ChannelManager mockChannelManager;
     private Producer mockProducer;
-    private Payload emptyPayload;
+    private RestPayload emptyPayload;
     private Message originalMessage;
     private Responder responder;
 
@@ -54,7 +54,7 @@ public class ResponderImplTest {
         msbContextSpy = spy(msbContext);
         mockChannelManager = mock(ChannelManager.class);
         mockProducer = mock(Producer.class);
-        emptyPayload = new Payload.Builder().build();
+        emptyPayload = new RestPayload.Builder().build();
         originalMessage = TestUtils.createSimpleRequestMessage(TOPIC);
 
         when(msbContextSpy.getChannelManager()).thenReturn(mockChannelManager);
@@ -91,7 +91,7 @@ public class ResponderImplTest {
     @Test
     public void testProducerPublishUseCorrectPayload() {
         String bodyText = "This is body";
-        Payload<?, ?, ?, String> simplePayload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload<?, ?, ?, String> simplePayload = TestUtils.createPayloadWithTextBody(bodyText);
 
         ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
         responder.send(simplePayload);

--- a/core/src/test/java/io/github/tcdl/msb/impl/ResponderServerImplTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/impl/ResponderServerImplTest.java
@@ -9,7 +9,7 @@ import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Responder;
 import io.github.tcdl.msb.api.ResponderServer;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.message.payload.MyPayload;
 import io.github.tcdl.msb.support.TestUtils;
 import org.junit.Before;
@@ -70,7 +70,7 @@ public class ResponderServerImplTest {
 
     @Test
     public void testResponderServerProcessDefaultPayloadSuccess() throws Exception {
-        ResponderServer.RequestHandler<Payload> handler = (request, responder) -> {
+        ResponderServer.RequestHandler<RestPayload> handler = (request, responder) -> {
         };
 
         ArgumentCaptor<MessageHandler> subscriberCaptor = ArgumentCaptor.forClass(MessageHandler.class);
@@ -80,7 +80,7 @@ public class ResponderServerImplTest {
         when(spyMsbContext.getChannelManager()).thenReturn(spyChannelManager);
 
         ResponderServerImpl responderServer = ResponderServerImpl
-                .create(TOPIC, requestOptions.getMessageTemplate(), spyMsbContext, handler, new TypeReference<Payload>() {});
+                .create(TOPIC, requestOptions.getMessageTemplate(), spyMsbContext, handler, new TypeReference<RestPayload>() {});
 
         ResponderServerImpl spyResponderServer = (ResponderServerImpl) spy(responderServer).listen();
 
@@ -99,18 +99,18 @@ public class ResponderServerImplTest {
 
     @Test
     public void testResponderServerProcessUnexpectedPayload() throws Exception {
-        ResponderServer.RequestHandler<Payload<?, ?, ?, Integer>> handler = (request, responder) -> {
+        ResponderServer.RequestHandler<RestPayload<?, ?, ?, Integer>> handler = (request, responder) -> {
         };
 
         String bodyText = "some body";
         Message incomingMessage = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
 
         ResponderServerImpl responderServer = ResponderServerImpl
-                .create(TOPIC, messageTemplate, msbContext, handler, new TypeReference<Payload<?, ?, ?, Integer>>() {});
+                .create(TOPIC, messageTemplate, msbContext, handler, new TypeReference<RestPayload<?, ?, ?, Integer>>() {});
         responderServer.listen();
 
         // simulate incoming request
-        ArgumentCaptor<Payload> responseCaptor = ArgumentCaptor.forClass(Payload.class);
+        ArgumentCaptor<RestPayload> responseCaptor = ArgumentCaptor.forClass(RestPayload.class);
         ResponderImpl responder = spy(
                 new ResponderImpl(messageTemplate, incomingMessage, msbContext));
         responderServer.onResponder(responder);
@@ -132,7 +132,7 @@ public class ResponderServerImplTest {
         responderServer.listen();
 
         // simulate incoming request
-        ArgumentCaptor<Payload> responseCaptor = ArgumentCaptor.forClass(Payload.class);
+        ArgumentCaptor<RestPayload> responseCaptor = ArgumentCaptor.forClass(RestPayload.class);
         ResponderImpl responder = spy(
                 new ResponderImpl(messageTemplate, TestUtils.createMsbRequestMessageNoPayload(TOPIC), msbContext));
         responderServer.onResponder(responder);

--- a/core/src/test/java/io/github/tcdl/msb/message/MessageFactoryTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/message/MessageFactoryTest.java
@@ -4,7 +4,7 @@ import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.Message.Builder;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.config.MsbConfig;
 import io.github.tcdl.msb.config.ServiceDetails;
 import io.github.tcdl.msb.support.TestUtils;
@@ -51,7 +51,7 @@ public class MessageFactoryTest {
     @Test
     public void testCreateRequestMessageWithPayload() {
         String bodyText = "body text";
-        Payload requestPayload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload requestPayload = TestUtils.createPayloadWithTextBody(bodyText);
 
         Builder requestMessageBuilder = TestUtils.createMessageBuilder(FIXED_CLOCK);
 
@@ -75,7 +75,7 @@ public class MessageFactoryTest {
     public void testCreateResponseMessageWithPayloadAndAck() {
         String bodyText = "body text";
         Builder responseMessageBuilder = TestUtils.createMessageBuilder(FIXED_CLOCK);
-        Payload responsePayload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload responsePayload = TestUtils.createPayloadWithTextBody(bodyText);
         Acknowledge ack = new Acknowledge.Builder()
                 .withResponderId(Utils.generateId())
                 .withResponsesRemaining(3)
@@ -101,7 +101,7 @@ public class MessageFactoryTest {
     @Test
     public void testBroadcastMessage() {
         String bodyText = "body text";
-        Payload broadcastPayload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload broadcastPayload = TestUtils.createPayloadWithTextBody(bodyText);
         Builder broadcastMessageBuilder = TestUtils.createMessageBuilder(FIXED_CLOCK);
 
         Message message = messageFactory.createBroadcastMessage(broadcastMessageBuilder, broadcastPayload);
@@ -224,7 +224,7 @@ public class MessageFactoryTest {
     @Test
     public void testCreateRequestMessageBuilderPublishedAtPresent() {
         String bodyText = "body text";
-        Payload requestPayload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload requestPayload = TestUtils.createPayloadWithTextBody(bodyText);
 
         Builder requestMessageBuilder = TestUtils.createMessageBuilder(FIXED_CLOCK);
 
@@ -239,7 +239,7 @@ public class MessageFactoryTest {
     //But the probability is very small
     public void testCreateRequestMessageBuilderPublishedAtIsAfterCreatedAt() {
         String bodyText = "body text";
-        Payload requestPayload = TestUtils.createPayloadWithTextBody(bodyText);
+        RestPayload requestPayload = TestUtils.createPayloadWithTextBody(bodyText);
 
         Builder requestMessageBuilder = TestUtils.createMessageBuilder(Clock.systemDefaultZone());
 

--- a/core/src/test/java/io/github/tcdl/msb/message/payload/MyPayload.java
+++ b/core/src/test/java/io/github/tcdl/msb/message/payload/MyPayload.java
@@ -1,6 +1,6 @@
 package io.github.tcdl.msb.message.payload;
 
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
-public class MyPayload extends Payload<Object, Object, Object, Body> {
+public class MyPayload extends RestPayload<Object, Object, Object, Body> {
 }

--- a/core/src/test/java/io/github/tcdl/msb/monitor/aggregator/DefaultChannelMonitorAggregatorTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/monitor/aggregator/DefaultChannelMonitorAggregatorTest.java
@@ -7,7 +7,7 @@ import io.github.tcdl.msb.MessageHandler;
 import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.AggregatorStats;
 import io.github.tcdl.msb.api.monitor.AggregatorTopicStats;
 import io.github.tcdl.msb.config.ServiceDetails;
@@ -293,7 +293,7 @@ public class DefaultChannelMonitorAggregatorTest {
         topicInfoMap.put(topic1, new AgentTopicStats().withProducers(true).withLastProducedAt(Instant.now()));
         topicInfoMap.put(topic2, new AgentTopicStats().withConsumers(true).withLastConsumedAt(Instant.now()));
 
-        Payload<?, ?, ?, Map<String, AgentTopicStats>> announcementPayload = new Payload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
+        RestPayload<?, ?, ?, Map<String, AgentTopicStats>> announcementPayload = new RestPayload.Builder<Object, Object, Object, Map<String, AgentTopicStats>>()
                 .withBody(topicInfoMap)
                 .build();
 

--- a/core/src/test/java/io/github/tcdl/msb/monitor/aggregator/HeartbeatTaskTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/monitor/aggregator/HeartbeatTaskTest.java
@@ -1,5 +1,6 @@
 package io.github.tcdl.msb.monitor.aggregator;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.RequestOptions;
@@ -27,7 +28,7 @@ public class HeartbeatTaskTest {
 
     private ObjectFactory mockObjectFactory = mock(ObjectFactory.class);
     @SuppressWarnings("unchecked")
-    private Requester<RestPayload> mockRequester = mock(Requester.class);
+    private Requester<JsonNode> mockRequester = mock(Requester.class);
     @SuppressWarnings("unchecked")
     private Callback<List<Message>> mockMessageHandler = mock(Callback.class);
     private HeartbeatTask heartbeatTask = new HeartbeatTask(ChannelMonitorAggregator.DEFAULT_HEARTBEAT_TIMEOUT_MS, mockObjectFactory, mockMessageHandler);

--- a/core/src/test/java/io/github/tcdl/msb/monitor/aggregator/HeartbeatTaskTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/monitor/aggregator/HeartbeatTaskTest.java
@@ -5,7 +5,7 @@ import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.message.Message;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.api.monitor.ChannelMonitorAggregator;
 import io.github.tcdl.msb.support.TestUtils;
 import io.github.tcdl.msb.support.Utils;
@@ -27,7 +27,7 @@ public class HeartbeatTaskTest {
 
     private ObjectFactory mockObjectFactory = mock(ObjectFactory.class);
     @SuppressWarnings("unchecked")
-    private Requester<Payload> mockRequester = mock(Requester.class);
+    private Requester<RestPayload> mockRequester = mock(Requester.class);
     @SuppressWarnings("unchecked")
     private Callback<List<Message>> mockMessageHandler = mock(Callback.class);
     private HeartbeatTask heartbeatTask = new HeartbeatTask(ChannelMonitorAggregator.DEFAULT_HEARTBEAT_TIMEOUT_MS, mockObjectFactory, mockMessageHandler);
@@ -55,7 +55,7 @@ public class HeartbeatTaskTest {
         verify(mockObjectFactory).createRequester(eq(Utils.TOPIC_HEARTBEAT), any(RequestOptions.class));
         verify(mockRequester).onRawResponse(onResponseCaptor.capture());
         verify(mockRequester).onEnd(onEndCaptor.capture());
-        verify(mockRequester).publish(any(Payload.class));
+        verify(mockRequester).publish(any(RestPayload.class));
 
         // simulate incoming messages
         Message msg1 = TestUtils.createSimpleRequestMessage("from:responder");

--- a/core/src/test/java/io/github/tcdl/msb/support/TestUtils.java
+++ b/core/src/test/java/io/github/tcdl/msb/support/TestUtils.java
@@ -15,7 +15,7 @@ import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.MetaMessage;
 import io.github.tcdl.msb.api.message.Topics;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.collector.CollectorManagerFactory;
 import io.github.tcdl.msb.collector.TimeoutManager;
 import io.github.tcdl.msb.config.MsbConfig;
@@ -109,7 +109,7 @@ public class TestUtils {
                 .build();
     }
 
-    public static Message createMsbRequestMessageWithCorrelationId(String topicTo, String correlationId, Payload payload) {
+    public static Message createMsbRequestMessageWithCorrelationId(String topicTo, String correlationId, RestPayload payload) {
         ObjectMapper payloadMapper = createMessageMapper();
         JsonNode payloadNode = Utils.convert(payload, JsonNode.class, payloadMapper);
         return createMsbRequestMessage(topicTo, null, correlationId, payloadNode);
@@ -135,7 +135,7 @@ public class TestUtils {
         }
     }
 
-    public static Message createMsbRequestMessage(String topicTo, String instanceId, Payload payload, String... tags) {
+    public static Message createMsbRequestMessage(String topicTo, String instanceId, RestPayload payload, String... tags) {
         ObjectMapper payloadMapper = createMessageMapper();
         JsonNode payloadNode = Utils.convert(payload, JsonNode.class, payloadMapper);
         return createMsbRequestMessage(topicTo, instanceId, null, payloadNode, tags);
@@ -162,8 +162,8 @@ public class TestUtils {
         return builder.build();
     }
 
-    public static Payload<Object, Object, Object, String> createPayloadWithTextBody(String bodyText) {
-        return new Payload.Builder<Object, Object, Object, String>()
+    public static RestPayload<Object, Object, Object, String> createPayloadWithTextBody(String bodyText) {
+        return new RestPayload.Builder<Object, Object, Object, String>()
                 .withBody(bodyText)
                 .build();
     }
@@ -217,7 +217,7 @@ public class TestUtils {
         return new MsbContextBuilder().createMessageEnvelopeMapper();
     }
 
-    public static Payload<Object, Map<String, String>, Object, Map<String, String>> createSimpleRequestPayload() {
+    public static RestPayload<Object, Map<String, String>, Object, Map<String, String>> createSimpleRequestPayload() {
         Map<String, String> headers = new HashMap<>();
         headers.put("url", "http://mock/request");
         headers.put("method", "Request");
@@ -226,25 +226,25 @@ public class TestUtils {
 
         body.put("body", "someRequestBody created at " + Clock.systemDefaultZone().millis());
 
-        return new Payload.Builder<Object, Map<String, String>, Object, Map<String, String>>()
+        return new RestPayload.Builder<Object, Map<String, String>, Object, Map<String, String>>()
                 .withHeaders(headers)
                 .withBody(body)
                 .withBodyBuffer(new byte[5])
                 .build();
     }
 
-    public static Payload<Object, Map<String, String>, Object, Map<String, String>> createSimpleRequestPayloadWithBodyBuffer(byte [] bodyBuffer) {
+    public static RestPayload<Object, Map<String, String>, Object, Map<String, String>> createSimpleRequestPayloadWithBodyBuffer(byte [] bodyBuffer) {
         Map<String, String> headers = new HashMap<>();
         headers.put("url", "http://mock/request");
         headers.put("method", "APPLICATION/OCTET-STREAM");
 
-        return new Payload.Builder<Object, Map<String, String>, Object, Map<String, String>>()
+        return new RestPayload.Builder<Object, Map<String, String>, Object, Map<String, String>>()
                 .withHeaders(headers)
                 .withBodyBuffer(bodyBuffer)
                 .build();
     }
 
-    public static Payload<Object, Map<String, String>, Object, Map<String, String>> createSimpleResponsePayload() {
+    public static RestPayload<Object, Map<String, String>, Object, Map<String, String>> createSimpleResponsePayload() {
         Map<String, String> headers = new HashMap<>();
         headers.put("statusCode", "200");
         headers.put("method", "Response");
@@ -252,7 +252,7 @@ public class TestUtils {
         Map<String, String> body = new HashMap<>();
         body.put("body", "someResponseBody");
 
-        return new Payload.Builder<Object, Map<String, String>, Object, Map<String, String>>()
+        return new RestPayload.Builder<Object, Map<String, String>, Object, Map<String, String>>()
                 .withHeaders(headers)
                 .withBody(body)
                 .build();
@@ -274,7 +274,7 @@ public class TestUtils {
         assertEquals(value, jsonObject.get(field).asText());
     }
 
-    public static void assertRequestMessagePayload(String json, Payload payload, String requestNamespace) {
+    public static void assertRequestMessagePayload(String json, RestPayload payload, String requestNamespace) {
         try {
             MsbContextImpl msbContext = TestUtils.createMsbContextBuilder().build();
             new JsonValidator().validate(json, msbContext.getMsbConfig().getSchema());
@@ -303,7 +303,7 @@ public class TestUtils {
         }
     }
 
-    public static void assertResponseMessagePayload(String json, Payload originalResponsePayload, String responseNamespace) {
+    public static void assertResponseMessagePayload(String json, RestPayload originalResponsePayload, String responseNamespace) {
         try {
             MsbContextImpl msbContext = TestUtils.createMsbContextBuilder().build();
             new JsonValidator().validate(json, msbContext.getMsbConfig().getSchema());

--- a/core/src/test/java/io/github/tcdl/msb/support/TestUtils.java
+++ b/core/src/test/java/io/github/tcdl/msb/support/TestUtils.java
@@ -54,7 +54,7 @@ public class TestUtils {
     }
 
     public static RequestOptions createSimpleRequestOptions() {
-        return new RequestOptions.Builder<>()
+        return new RequestOptions.Builder()
                 .withMessageTemplate(createSimpleMessageTemplate())
                 .build();
     }
@@ -62,7 +62,7 @@ public class TestUtils {
     public static RequestOptions createSimpleRequestOptionsWithTags(String... tags) {
         MessageTemplate messageTemplate = createSimpleMessageTemplate();
         messageTemplate.withTags(tags);
-        return new RequestOptions.Builder<>()
+        return new RequestOptions.Builder()
                 .withMessageTemplate(messageTemplate)
                 .build();
     }

--- a/examples/src/main/java/io/github/tcdl/msb/examples/DateExtractor.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/DateExtractor.java
@@ -3,7 +3,7 @@ package io.github.tcdl.msb.examples;
 import io.github.tcdl.msb.api.MessageTemplate;
 import io.github.tcdl.msb.api.MsbContext;
 import io.github.tcdl.msb.api.MsbContextBuilder;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.examples.payload.Query;
 import io.github.tcdl.msb.examples.payload.Request;
 
@@ -54,7 +54,7 @@ public class DateExtractor {
 
                 ResponseBody responseBody = new ResponseBody();
                 responseBody.setResults(Arrays.asList(result));
-                Payload responsePayload = new Payload.Builder<Object, Object, Object, ResponseBody>()
+                RestPayload responsePayload = new RestPayload.Builder<Object, Object, Object, ResponseBody>()
                         .withStatusCode(200)
                         .withBody(responseBody)
                         .build();

--- a/examples/src/main/java/io/github/tcdl/msb/examples/FacetsAggregator.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/FacetsAggregator.java
@@ -6,7 +6,7 @@ import io.github.tcdl.msb.api.MsbContextBuilder;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
 import io.github.tcdl.msb.api.Responder;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import io.github.tcdl.msb.examples.payload.Request;
 
 import javax.script.ScriptException;
@@ -39,7 +39,7 @@ public class FacetsAggregator {
             String q = facetsRequest.getQuery().getQ();
 
             if (q == null) {
-                Payload responsePayload = new Payload.Builder()
+                RestPayload responsePayload = new RestPayload.Builder()
                         .withStatusCode(400)
                         .build();
                 responder.send(responsePayload);
@@ -55,7 +55,7 @@ public class FacetsAggregator {
 
                 responseBodyAny.setFacets(Collections.singletonList(facet));
 
-                Payload responsePayloadAny = new Payload.Builder<Object, Object, Object, ResponseBodyAny>()
+                RestPayload responsePayloadAny = new RestPayload.Builder<Object, Object, Object, ResponseBodyAny>()
                         .withStatusCode(200)
                         .withBody(responseBodyAny)
                         .build();
@@ -69,20 +69,20 @@ public class FacetsAggregator {
                         .withResponseTimeout(600)
                         .build();
 
-                Requester<Payload> requester = msbContext.getObjectFactory().createRequester("search:parsers:facets:v1",
-                        requestOptions, Payload.class);
+                Requester<RestPayload> requester = msbContext.getObjectFactory().createRequester("search:parsers:facets:v1",
+                        requestOptions, RestPayload.class);
 
                 final String[] result = {""};
 
-                List<Payload> responses = Collections.synchronizedList(new ArrayList<>());
+                List<RestPayload> responses = Collections.synchronizedList(new ArrayList<>());
                 requester.onResponse(responses::add)
                 .onEnd(end -> {
-                    for (Payload payload : responses) {
+                    for (RestPayload payload : responses) {
                         System.out.println(">>> MESSAGE: " + payload);
                         result[0] += payload;
                     }
 
-                    Payload responsePayload = new Payload.Builder<Object, Object, Object, String>()
+                    RestPayload responsePayload = new RestPayload.Builder<Object, Object, Object, String>()
                             .withStatusCode(200)
                             .withBody(result[0])
                             .build();

--- a/examples/src/main/java/io/github/tcdl/msb/examples/PingService.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/PingService.java
@@ -6,7 +6,6 @@ import io.github.tcdl.msb.api.MsbContextBuilder;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,14 +28,10 @@ public class PingService {
                 .build();
 
         ObjectFactory objectFactory = msbContext.getObjectFactory();
-        Requester<RestPayload> requester = objectFactory.createRequester("pingpong:namespace", requestOptions)
-                .onResponse(payload -> LOG.info(String.format("Received response '%s'", payload.getBody()))) // Handling the one response
+        Requester<String> requester = objectFactory.createRequester("pingpong:namespace", requestOptions, String.class)
+                .onResponse(payload -> LOG.info(String.format("Received response '%s'", payload))) // Handling the one response
                 .onEnd(arg -> LOG.info("Received all expected responses")); // Handling all response arrival or timeout
 
-        RestPayload pingPayload = new RestPayload.Builder<Object, Object, Object, String>()
-                .withBody("PING")
-                .build();
-
-        requester.publish(pingPayload, UUID.randomUUID().toString()); // Send the message
+        requester.publish("PING", UUID.randomUUID().toString()); // Send the message
     }
 }

--- a/examples/src/main/java/io/github/tcdl/msb/examples/PingService.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/PingService.java
@@ -6,7 +6,7 @@ import io.github.tcdl.msb.api.MsbContextBuilder;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.RequestOptions;
 import io.github.tcdl.msb.api.Requester;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,11 +29,11 @@ public class PingService {
                 .build();
 
         ObjectFactory objectFactory = msbContext.getObjectFactory();
-        Requester<Payload> requester = objectFactory.createRequester("pingpong:namespace", requestOptions)
+        Requester<RestPayload> requester = objectFactory.createRequester("pingpong:namespace", requestOptions)
                 .onResponse(payload -> LOG.info(String.format("Received response '%s'", payload.getBody()))) // Handling the one response
                 .onEnd(arg -> LOG.info("Received all expected responses")); // Handling all response arrival or timeout
 
-        Payload pingPayload = new Payload.Builder<Object, Object, Object, String>()
+        RestPayload pingPayload = new RestPayload.Builder<Object, Object, Object, String>()
                 .withBody("PING")
                 .build();
 

--- a/examples/src/main/java/io/github/tcdl/msb/examples/PongService.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/PongService.java
@@ -5,7 +5,7 @@ import io.github.tcdl.msb.api.MsbContext;
 import io.github.tcdl.msb.api.MsbContextBuilder;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.ResponderServer;
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +23,7 @@ public class PongService {
             // Response handling logic
             LOG.info(String.format("Handling %s...", request.getBody()));
 
-            Payload pongPayload = new Payload.Builder<Object, Object, Object, String>()
+            RestPayload pongPayload = new RestPayload.Builder<Object, Object, Object, String>()
                     .withBody("PONG")
                     .build();
 

--- a/examples/src/main/java/io/github/tcdl/msb/examples/PongService.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/PongService.java
@@ -5,7 +5,6 @@ import io.github.tcdl.msb.api.MsbContext;
 import io.github.tcdl.msb.api.MsbContextBuilder;
 import io.github.tcdl.msb.api.ObjectFactory;
 import io.github.tcdl.msb.api.ResponderServer;
-import io.github.tcdl.msb.api.message.payload.RestPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,16 +20,12 @@ public class PongService {
         MessageTemplate messageTemplate = new MessageTemplate().withTags("pong-static-tag");
         ResponderServer responderServer = objectFactory.createResponderServer("pingpong:namespace", messageTemplate, (request, responder) -> {
             // Response handling logic
-            LOG.info(String.format("Handling %s...", request.getBody()));
+            LOG.info(String.format("Handling %s...", request));
 
-            RestPayload pongPayload = new RestPayload.Builder<Object, Object, Object, String>()
-                    .withBody("PONG")
-                    .build();
-
-            responder.send(pongPayload);
+            responder.send("PONG");
 
             LOG.info("Response sent");
-        });
+        }, String.class);
         responderServer.listen(); // Need not forget to hook up the responder server
     }
 }

--- a/examples/src/main/java/io/github/tcdl/msb/examples/payload/Request.java
+++ b/examples/src/main/java/io/github/tcdl/msb/examples/payload/Request.java
@@ -1,6 +1,6 @@
 package io.github.tcdl.msb.examples.payload;
 
-import io.github.tcdl.msb.api.message.payload.Payload;
+import io.github.tcdl.msb.api.message.payload.RestPayload;
 
-public class Request extends Payload<Query, Object, Object, Object> {
+public class Request extends RestPayload<Query, Object, Object, Object> {
 }


### PR DESCRIPTION
Description of changes:
1. Renamed `Payload` -> `RestPayload`
2. Removed constraints on type parameters in `Requester` and `ResponderServer`
3. Used `RestPayload` when sending back error codes (for example 500)
4. Default type is `JsonNode` for requester/responder servers obtained from `ObjectFactory`
5. Updated example `PingService` and `PongService` to use plain string payload
6. Updated dev guide
