### PR TITLE
Web 16849 onEnd callback fix

### DIFF
--- a/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MsbTestHelper.java
+++ b/acceptance/src/main/java/io/github/tcdl/msb/acceptance/MsbTestHelper.java
@@ -92,11 +92,21 @@ public class MsbTestHelper {
     }
 
     public <T> void sendRequest(Requester<T> requester, Object payload, Integer waitForResponses, Callback<T> responseCallback) throws Exception {
-        sendRequest(requester, payload, true, waitForResponses, null, responseCallback);
+        sendRequest(requester, payload, true, waitForResponses, null, responseCallback, null);
+    }
+
+    public <T> void sendRequest(Requester<T> requester, Object payload, Integer waitForResponses, Callback<T> responseCallback, Callback<Void> endCallback) throws Exception {
+        sendRequest(requester, payload, true, waitForResponses, null, responseCallback, endCallback);
     }
 
     public <T> void sendRequest(Requester<T> requester, Object payload, boolean waitForAck, Integer waitForResponses,
             Callback<Acknowledge> ackCallback, Callback<T> responseCallback) throws Exception {
+        sendRequest(requester, payload, waitForAck, waitForResponses,
+                 ackCallback, responseCallback, null);
+    }
+
+    public <T> void sendRequest(Requester<T> requester, Object payload, boolean waitForAck, Integer waitForResponses,
+            Callback<Acknowledge> ackCallback, Callback<T> responseCallback, Callback<Void> endCallback) throws Exception {
 
         requester.onAcknowledge((acknowledge, ackHandler) -> {
             System.out.println(">>> ACKNOWLEDGE: " + acknowledge);
@@ -108,6 +118,13 @@ public class MsbTestHelper {
             System.out.println(">>> RESPONSE: " + response);
             if (waitForResponses != null && waitForResponses > 0 && responseCallback != null) {
                 responseCallback.call(response);
+            }
+        });
+
+        requester.onEnd((end) -> {
+            System.out.println(">>> END: ");
+            if(endCallback != null) {
+                endCallback.call(null);
             }
         });
 

--- a/acceptance/src/test/java/io/github/tcdl/msb/acceptance/bdd/steps/RequesterResponderSteps.java
+++ b/acceptance/src/test/java/io/github/tcdl/msb/acceptance/bdd/steps/RequesterResponderSteps.java
@@ -174,21 +174,21 @@ public class RequesterResponderSteps extends MsbSteps {
     public void sendRequest(String contextName) throws Exception {
         onBeforeRequest();
         RestPayload<?, ?, ?, ?> payload = helper.createFacetParserPayload("QUERY", null);
-        helper.sendRequest(requester, payload, responsesToExpectCount, this::onResponse);
+        helper.sendRequest(requester, payload, responsesToExpectCount, this::onResponse, this::onEnd);
     }
 
     @When("requester sends a request with query '$query'")
     public void sendRequestWithQuery(String query) throws Exception {
         onBeforeRequest();
         RestPayload<?, ?, ?, ?> payload = helper.createFacetParserPayload(query, null);
-        helper.sendRequest(requester, payload, true, responsesToExpectCount, null, this::onResponse);
+        helper.sendRequest(requester, payload, true, responsesToExpectCount, null, this::onResponse, this::onEnd);
     }
 
     @When("requester sends a request with body '$body'")
     public void sendRequestWithBody(String body) throws Exception {
         onBeforeRequest();
         RestPayload<?, ?, ?, ?> payload = helper.createFacetParserPayload(null, body);
-        helper.sendRequest(requester, payload, true, responsesToExpectCount, null, this::onResponse);
+        helper.sendRequest(requester, payload, true, responsesToExpectCount, null, this::onResponse, this::onEnd);
     }
 
     private void onBeforeRequest() {
@@ -211,6 +211,12 @@ public class RequesterResponderSteps extends MsbSteps {
 
         countResponsesReceived.incrementAndGet();
         receivedResponseFuture.complete(payload.getBody());
+    }
+
+    private void onEnd(Void in) {
+        if(responseCountDown != null && responseCountDown.getCount() > 0) {
+            Assert.fail("onEnd has been executed while not all responses were received yet, pending responses count: " + responseCountDown.getCount());
+        }
     }
 
     @Then("requester gets response in $timeout ms")

--- a/core/src/main/java/io/github/tcdl/msb/adapters/MessageHandlerInvokeStrategy.java
+++ b/core/src/main/java/io/github/tcdl/msb/adapters/MessageHandlerInvokeStrategy.java
@@ -2,6 +2,7 @@ package io.github.tcdl.msb.adapters;
 
 import io.github.tcdl.msb.MessageHandler;
 import io.github.tcdl.msb.acknowledge.AcknowledgementHandlerInternal;
+import io.github.tcdl.msb.api.AcknowledgementHandler;
 import io.github.tcdl.msb.api.message.Message;
 
 /**
@@ -13,9 +14,13 @@ public interface MessageHandlerInvokeStrategy {
      * {@link AcknowledgementHandlerInternal} methods should be invoked (depending on result -
      * {@link AcknowledgementHandlerInternal#autoConfirm()} should be used the processing was successful):
      * it is required to call in order to confirm the message.
+     * The method should always throw an exception when a message supplied can't be handled
+     * so there will be no {@link MessageHandler#handleMessage(Message, AcknowledgementHandler)} invocation.
+     *
      * @param messageHandler {@link MessageHandler} instance related to a {@link Message} to be processed.
      * @param message  {@link Message} to be processed.
      * @param acknowledgeHandler acknowledgement handler.
+     * @throws RuntimeException when a message can't be handled.
      */
     void execute(MessageHandler messageHandler, Message message, AcknowledgementHandlerInternal acknowledgeHandler);
 }

--- a/core/src/main/java/io/github/tcdl/msb/collector/Collector.java
+++ b/core/src/main/java/io/github/tcdl/msb/collector/Collector.java
@@ -147,6 +147,9 @@ public class Collector<T> implements ConsumedMessagesAwareMessageHandler {
     @Override
     public synchronized void notifyConsumedMessageIsLost() {
         consumedAndLostMessagesCount.increment();
+        if(isNoMoreMessagesHandlingPossible()) {
+            end();
+        }
     }
 
     boolean isAwaitingAcks() {

--- a/core/src/main/java/io/github/tcdl/msb/collector/ConsumedMessagesAwareMessageHandler.java
+++ b/core/src/main/java/io/github/tcdl/msb/collector/ConsumedMessagesAwareMessageHandler.java
@@ -1,0 +1,23 @@
+package io.github.tcdl.msb.collector;
+
+import io.github.tcdl.msb.MessageHandler;
+import io.github.tcdl.msb.api.AcknowledgementHandler;
+import io.github.tcdl.msb.api.message.Message;
+
+/**
+ * Interface used to notify {@link io.github.tcdl.msb.MessageHandler} regarding a count
+ * of expected  {@link io.github.tcdl.msb.MessageHandler#handleMessage(Message, AcknowledgementHandler)} invocations.
+ */
+public interface ConsumedMessagesAwareMessageHandler extends MessageHandler {
+    /**
+     * Should be invoked when an incoming message has been consumed so {@link io.github.tcdl.msb.MessageHandler#handleMessage(Message, AcknowledgementHandler)}
+     * will be invoked to process it in future.
+     */
+    void notifyMessageConsumed();
+
+    /**
+     * Should be invoked when an incoming message that was consumed previously has been lost so {@link io.github.tcdl.msb.MessageHandler#handleMessage(Message, AcknowledgementHandler)}
+     * invocation is no longer expected.
+     */
+    void notifyConsumedMessageIsLost();
+}

--- a/core/src/test/java/io/github/tcdl/msb/api/ChannelMonitorIT.java
+++ b/core/src/test/java/io/github/tcdl/msb/api/ChannelMonitorIT.java
@@ -146,16 +146,19 @@ public class ChannelMonitorIT {
         //need to await for original request for heartbeat to be send to simulate response with same correlationId
         Message requestMessage = awaitHeartBeatRequestSent();
 
-        Message brokenResponseMessage = TestUtils.createMsbRequestMessageWithCorrelationId(requestMessage.getTopics().getResponse(),
+        Message brokenResponseMessage1 = TestUtils.createMsbRequestMessageWithCorrelationId(requestMessage.getTopics().getResponse(),
+                requestMessage.getCorrelationId(),
+                " unexpected statistics format received");
+        Message brokenResponseMessage2 = TestUtils.createMsbRequestMessageWithCorrelationId(requestMessage.getTopics().getResponse(),
                 requestMessage.getCorrelationId(),
                 " unexpected statistics format received");
         Message responseMessage = TestUtils
                 .createMsbRequestMessageWithCorrelationId(requestMessage.getTopics().getResponse(), requestMessage.getCorrelationId(),
                         payload);
         //simulate 3 heartbeatResponses: 1 valid and 2 broken
-        MockAdapter.pushRequestMessage(requestMessage.getTopics().getResponse(), Utils.toJson(brokenResponseMessage, msbContext.getPayloadMapper()));
+        MockAdapter.pushRequestMessage(requestMessage.getTopics().getResponse(), Utils.toJson(brokenResponseMessage1, msbContext.getPayloadMapper()));
         MockAdapter.pushRequestMessage(requestMessage.getTopics().getResponse(), Utils.toJson(responseMessage, msbContext.getPayloadMapper()));
-        MockAdapter.pushRequestMessage(requestMessage.getTopics().getResponse(), Utils.toJson(brokenResponseMessage, msbContext.getPayloadMapper()));
+        MockAdapter.pushRequestMessage(requestMessage.getTopics().getResponse(), Utils.toJson(brokenResponseMessage2, msbContext.getPayloadMapper()));
 
         assertTrue("Heartbeat response was not received",
                 heartBeatResponseReceived.await(HEARTBEAT_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS));

--- a/core/src/test/java/io/github/tcdl/msb/collector/CollectorTest.java
+++ b/core/src/test/java/io/github/tcdl/msb/collector/CollectorTest.java
@@ -1,25 +1,19 @@
 package io.github.tcdl.msb.collector;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
 import io.github.tcdl.msb.ChannelManager;
 import io.github.tcdl.msb.api.AcknowledgementHandler;
 import io.github.tcdl.msb.api.Callback;
 import io.github.tcdl.msb.api.MessageContext;
 import io.github.tcdl.msb.api.RequestOptions;
-import io.github.tcdl.msb.api.exception.JsonConversionException;
 import io.github.tcdl.msb.api.message.Acknowledge;
 import io.github.tcdl.msb.api.message.Message;
 import io.github.tcdl.msb.api.message.payload.RestPayload;
@@ -32,9 +26,11 @@ import io.github.tcdl.msb.support.Utils;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiConsumer;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -174,6 +170,7 @@ public class CollectorTest {
         };
         
         // method under test
+        notifyMessagesConsumed(collector, 1);
         collector.handleMessage(responseMessage, acknowledgeHandler);
 
         RestPayload<?, ?, ?, String> expectedPayload = new RestPayload.Builder<Object, Object, Object, String>()
@@ -187,7 +184,6 @@ public class CollectorTest {
         assertFalse(collector.getAckMessages().contains(responseMessage));
     }
 
-    @Test(expected = JsonConversionException.class)
     public void testHandleResponseConversionFailed() {
         String bodyText = "some body";
         Message responseMessage = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
@@ -214,12 +210,11 @@ public class CollectorTest {
         };
 
         // make sure that onRawResponse is called even if conversion of payload to custom type fails
-        try {
-            collector.handleMessage(responseMessage, ackHandler);
-        } finally {
-            verify(onRawResponse).accept(responseMessage, messageContext);
-            verify(onResponse, never()).accept(any(), any());
-        }
+
+        collector.handleMessage(responseMessage, ackHandler);
+
+        verify(onRawResponse).accept(responseMessage, messageContext);
+        verify(onResponse, never()).accept(any(), any());
     }
 
     @Test
@@ -244,6 +239,7 @@ public class CollectorTest {
         when(eventHandlers.onEnd()).thenReturn(onEnd);
         Collector<RestPayload> collector = createCollector();
 
+        notifyMessagesConsumed(collector, 1);
         AcknowledgementHandler ackHandler = mock(AcknowledgementHandler.class);
         collector.handleMessage(responseMessageWithAck, ackHandler);
 
@@ -271,6 +267,8 @@ public class CollectorTest {
         when(eventHandlers.onEnd()).thenReturn(onEnd);
 
         Collector<RestPayload> collector = createCollector();
+
+        notifyMessagesConsumed(collector, 1);
         AcknowledgementHandler ackHandler = mock(AcknowledgementHandler.class);
         collector.handleMessage(responseMessage, ackHandler);
 
@@ -287,8 +285,8 @@ public class CollectorTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void testHandleResponseWaitForOneMoreResponse() {
         String bodyText = "some body";
-        Message responseMessage = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
-
+        Message responseMessage1 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+        Message responseMessage2 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
         /*ackTimeout = 0, responseTimeout=200; waitForResponses = 2
         */
         int responseTimeout = 200;
@@ -309,13 +307,16 @@ public class CollectorTest {
                 .build();
 
         AcknowledgementHandler ackHandler = mock(AcknowledgementHandler.class);
+
         //send first response
-        collector.handleMessage(responseMessage, ackHandler);
+        notifyMessagesConsumed(collector, 1);
+        collector.handleMessage(responseMessage1, ackHandler);
         verify(onResponse).accept(expectedPayload, messageContextMock);
         verify(onEnd, never()).call(any());
 
         //send last response
-        collector.handleMessage(responseMessage, ackHandler);
+        notifyMessagesConsumed(collector, 1);
+        collector.handleMessage(responseMessage2, ackHandler);
         verify(onResponse, times(2)).accept(expectedPayload, messageContextMock);
         verify(timeoutManagerMock, never()).enableResponseTimeout(eq(responseTimeout), eq(collector));
         verify(timeoutManagerMock, never()).enableAckTimeout(eq(0), eq(collector));
@@ -404,6 +405,7 @@ public class CollectorTest {
 
         AcknowledgementHandler ackHandler = mock(AcknowledgementHandler.class);
         //send payload response
+        notifyMessagesConsumed(collector, 1);
         collector.handleMessage(responseMessage, ackHandler);
         verify(timeoutManagerMock, never()).enableResponseTimeout(eq(0), eq(collector));
         verify(timeoutManagerMock, never()).enableAckTimeout(eq(ackTimeoutMs), eq(collector));
@@ -429,6 +431,7 @@ public class CollectorTest {
         Acknowledge ack = new Acknowledge.Builder().withResponderId(Utils.generateId()).withResponsesRemaining(0).withTimeoutMs(timeoutMs).build();
         Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
 
+        notifyMessagesConsumed(collector, 1);
         AcknowledgementHandler ackHandler = mock(AcknowledgementHandler.class);
         collector.handleMessage(responseMessageWithAck, ackHandler);
 
@@ -457,6 +460,7 @@ public class CollectorTest {
                 .build();
         Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
 
+        notifyMessagesConsumed(collector, 1);
         AcknowledgementHandler ackHandler = mock(AcknowledgementHandler.class);
         collector.handleMessage(responseMessageWithAck, ackHandler);
 
@@ -544,8 +548,8 @@ public class CollectorTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void testHandleResponseEnsureResponsesRemainingIsDecreased() {
         String bodyText = "some body";
-        Message responseMessage = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
-
+        Message responseMessage1 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+        Message responseMessage2 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
         /*ackTimeout = 0, responseTimeout=200; waitForResponses = 2
         */
         int responseTimeout = 200;
@@ -564,16 +568,131 @@ public class CollectorTest {
 
         assertEquals(responsesRemaining, collector.getResponsesRemaining());
 
+        notifyMessagesConsumed(collector, 2);
         //send first response
-        collector.handleMessage(responseMessage, null);
+        collector.handleMessage(responseMessage1, null);
         assertEquals(1, collector.getResponsesRemaining());
         verify(onEnd, never()).call(any());
 
         //send last response
-        collector.handleMessage(responseMessage, null);
+        collector.handleMessage(responseMessage2, null);
         assertEquals(0, collector.getResponsesRemaining());
         verify(onEnd).call(any());
     }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testHandleResponseRedelivery() {
+        String bodyText = "some body";
+        Message responseMessage1 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+        Message responseMessage2 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+        /*ackTimeout = 0, responseTimeout=200; waitForResponses = 2
+        */
+        int responseTimeout = 200;
+        int responsesRemaining = 2;
+        when(requestOptionsMock.getAckTimeout()).thenReturn(0);
+        when(requestOptionsMock.getResponseTimeout()).thenReturn(responseTimeout);
+        when(requestOptionsMock.getWaitForResponses()).thenReturn(responsesRemaining);
+
+        BiConsumer<RestPayload, MessageContext> onResponse = mock(BiConsumer.class);
+        when(eventHandlers.onResponse()).thenReturn(onResponse);
+        Callback<Void> onEnd = mock(Callback.class);
+        when(eventHandlers.onEnd()).thenReturn(onEnd);
+
+        Collector<RestPayload> collector = createCollector();
+        collector.listenForResponses();
+
+        assertEquals(responsesRemaining, collector.getResponsesRemaining());
+
+        notifyMessagesConsumed(collector, 2);
+        //send first response
+        collector.handleMessage(responseMessage1, null);
+        assertEquals(1, collector.getResponsesRemaining());
+        verify(onEnd, never()).call(any());
+
+        //redeliver first response
+        collector.handleMessage(responseMessage1, null);
+        assertEquals(1, collector.getResponsesRemaining());
+        verify(onEnd, never()).call(any());
+
+        notifyMessagesConsumed(collector, 1);
+        //send last response
+        collector.handleMessage(responseMessage2, null);
+        assertEquals(0, collector.getResponsesRemaining());
+        verify(onEnd).call(any());
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testEndInvokedWhenOnResponseCallbacksThrowExceptions() {
+        String bodyText = "some body";
+        Message responseMessage1 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+        Message responseMessage2 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+        /*ackTimeout = 0, responseTimeout=200; waitForResponses = 2
+        */
+        int responseTimeout = 200;
+        int responsesRemaining = 2;
+        when(requestOptionsMock.getAckTimeout()).thenReturn(0);
+        when(requestOptionsMock.getResponseTimeout()).thenReturn(responseTimeout);
+        when(requestOptionsMock.getWaitForResponses()).thenReturn(responsesRemaining);
+
+        BiConsumer<RestPayload, MessageContext> onResponse = mock(BiConsumer.class);
+        when(eventHandlers.onResponse()).thenReturn(onResponse);
+        doThrow(new RuntimeException("Unexpected error in a callback!")).when(onResponse).accept(any(), any());
+
+        Callback<Void> onEnd = mock(Callback.class);
+        when(eventHandlers.onEnd()).thenReturn(onEnd);
+
+        Collector<RestPayload> collector = createCollector();
+        collector.listenForResponses();
+
+        assertEquals(responsesRemaining, collector.getResponsesRemaining());
+
+        notifyMessagesConsumed(collector, 2);
+
+        //send first response
+        collector.handleMessage(responseMessage1, null);
+        verify(onEnd, never()).call(any());
+
+        collector.handleMessage(responseMessage2, null);
+
+        verify(onEnd, times(1)).call(any());
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testEndThrowsExceptions() {
+        String bodyText = "some body";
+        Message responseMessage1 = TestUtils.createMsbRequestMessage(TOPIC, bodyText);
+
+        /*ackTimeout = 0, responseTimeout=200; waitForResponses = 2
+        */
+        int responseTimeout = 200;
+        int responsesRemaining = 1;
+        when(requestOptionsMock.getAckTimeout()).thenReturn(0);
+        when(requestOptionsMock.getResponseTimeout()).thenReturn(responseTimeout);
+        when(requestOptionsMock.getWaitForResponses()).thenReturn(responsesRemaining);
+
+        BiConsumer<RestPayload, MessageContext> onResponse = mock(BiConsumer.class);
+        when(eventHandlers.onResponse()).thenReturn(onResponse);
+
+        Callback<Void> onEnd = mock(Callback.class);
+        when(eventHandlers.onEnd()).thenReturn(onEnd);
+
+        doThrow(new RuntimeException("Unexpected error in a callback!")).when(onEnd).call(any());
+
+        Collector<RestPayload> collector = createCollector();
+        collector.listenForResponses();
+
+        assertEquals(responsesRemaining, collector.getResponsesRemaining());
+
+        notifyMessagesConsumed(collector, 1);
+
+        //send first response
+        collector.handleMessage(responseMessage1, null);
+        verify(onEnd, times(1)).call(any());
+    }
+
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -601,9 +720,67 @@ public class CollectorTest {
         Collector<RestPayload> collector = createCollector();
         collector.listenForResponses();
 
+        notifyMessagesConsumed(collector, 1);
         Acknowledge ack = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(1).withTimeoutMs(timeoutMsInAck)
                 .build();
         Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
+        collector.handleMessage(responseMessageWithAck, null);
+
+        //simulate responder response
+        notifyMessagesConsumed(collector, 1);
+        Acknowledge responseAck = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(-1).build();
+        ObjectMapper payloadMapper = TestUtils.createMessageMapper();
+        JsonNode payloadNode = payloadMapper.readValue(String.format("{\"body\": \"%s\" }", "test response payload body"), JsonNode.class);
+
+        Message responderMessage = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE, "someCorrelationId");
+
+        //send message
+        collector.handleMessage(responderMessage, null);
+
+        verify(onEnd, after(1500).times(1)).call(any());
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testTimeoutFiredWhileMessagesExpected() throws InterruptedException, IOException {
+        int timeoutMs = 300;
+        int timeoutMsInAck = 600;
+        String responderId = "b";
+
+        when(requestOptionsMock.getAckTimeout()).thenReturn(0);
+        when(requestOptionsMock.getResponseTimeout()).thenReturn(timeoutMs);
+        when(requestOptionsMock.getWaitForResponses()).thenReturn(0);
+
+        this.msbContext = TestUtils.createMsbContextBuilder()
+                .withMsbConfigurations(msbConfigurationsMock)
+                .withMessageFactory(messageFactoryMock)
+                .withChannelManager(channelManagerMock)
+                .withClock(Clock.systemDefaultZone())
+                .withTimeoutManager(new TimeoutManager(1))
+                .withCollectorManagerFactory(collectorManagerFactoryMock)
+                .build();
+
+        Callback<Void> onEnd = mock(Callback.class);
+        when(eventHandlers.onEnd()).thenReturn(onEnd);
+
+        @SuppressWarnings("unchecked")
+        BiConsumer<RestPayload, MessageContext> onResponse = (restPayload, messageContext) -> {
+            try {
+                Thread.sleep(900);
+            } catch (InterruptedException e) {
+                fail("Interrupted");
+            }
+        };
+
+        when(eventHandlers.onResponse()).thenReturn(onResponse);
+
+        Collector<RestPayload> collector = createCollector();
+        collector.listenForResponses();
+
+        Acknowledge ack = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(99).withTimeoutMs(timeoutMsInAck)
+                .build();
+        Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
+        notifyMessagesConsumed(collector, 1);
         collector.handleMessage(responseMessageWithAck, null);
 
         //simulate responder response
@@ -614,9 +791,133 @@ public class CollectorTest {
         Message responderMessage = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE, "someCorrelationId");
 
         //send message
+        notifyMessagesConsumed(collector, 1);
         collector.handleMessage(responderMessage, null);
 
-        verify(onEnd, timeout(1500)).call(any());
+        verify(onEnd, after(1500).times(1)).call(any());
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testTimeoutFiredDuringMessageHandling() throws Exception {
+        int timeoutMs = 300;
+        int timeoutMsInAck = 600;
+        String responderId = "b";
+
+        when(requestOptionsMock.getAckTimeout()).thenReturn(0);
+        when(requestOptionsMock.getResponseTimeout()).thenReturn(timeoutMs);
+        when(requestOptionsMock.getWaitForResponses()).thenReturn(0);
+
+        this.msbContext = TestUtils.createMsbContextBuilder()
+                .withMsbConfigurations(msbConfigurationsMock)
+                .withMessageFactory(messageFactoryMock)
+                .withChannelManager(channelManagerMock)
+                .withClock(Clock.systemDefaultZone())
+                .withTimeoutManager(new TimeoutManager(1))
+                .withCollectorManagerFactory(collectorManagerFactoryMock)
+                .build();
+
+        CompletableFuture<Long> timeOnEnd = new CompletableFuture<>();
+        CompletableFuture<Long>  timeAfterHandler = new CompletableFuture<>();
+        LongAdder onEndCounter = new LongAdder();
+
+        Callback<Void> onEnd = (Void in) -> {
+            System.out.println("onEnd invoked");
+            onEndCounter.increment();
+            timeOnEnd.complete(System.currentTimeMillis());
+        };
+
+        when(eventHandlers.onEnd()).thenReturn(onEnd);
+
+        @SuppressWarnings("unchecked")
+        BiConsumer<RestPayload, MessageContext> onResponse = (restPayload, messageContext) -> {
+            try {
+                System.out.println("slow onResponse start");
+                Thread.sleep(1500);
+                timeAfterHandler.complete(System.currentTimeMillis());
+                System.out.println("slow onResponse finish");
+            } catch (InterruptedException e) {
+                fail("Interrupted");
+            }
+        };
+
+        when(eventHandlers.onResponse()).thenReturn(onResponse);
+
+        Collector<RestPayload> collector = createCollector();
+        collector.listenForResponses();
+
+        Acknowledge ack = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(1).withTimeoutMs(timeoutMsInAck)
+                .build();
+        Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
+        notifyMessagesConsumed(collector, 1);
+        collector.handleMessage(responseMessageWithAck, null);
+
+        //simulate responder response
+        Acknowledge responseAck = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(-1).build();
+        ObjectMapper payloadMapper = TestUtils.createMessageMapper();
+        JsonNode payloadNode = payloadMapper.readValue(String.format("{\"body\": \"%s\" }", "test response payload body"), JsonNode.class);
+
+        Message responderMessage = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE, "someCorrelationId");
+
+        //send message
+        notifyMessagesConsumed(collector, 1);
+        collector.handleMessage(responderMessage, null);
+        long timeAfterHandlerValue = timeAfterHandler.get(2000, TimeUnit.MILLISECONDS);
+        long timeOnEndValue = timeOnEnd.get(2000, TimeUnit.MILLISECONDS);
+
+        assertTrue("onEnd should not be invoked by timer: it should be invoked after the last message handling instead: "
+                + "handler complete:" + timeAfterHandlerValue + ", onEnd invoked:" + timeOnEndValue,
+                timeAfterHandlerValue <= timeOnEndValue);
+        assertEquals(1, onEndCounter.intValue());
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testHandleResponseReceivedAckWithUpdatedTimeoutAndOneResponseLost() throws InterruptedException, IOException {
+        int timeoutMs = 200;
+        int timeoutMsInAck = 500;
+        String responderId = "b";
+
+        when(requestOptionsMock.getAckTimeout()).thenReturn(0);
+        when(requestOptionsMock.getResponseTimeout()).thenReturn(timeoutMs);
+        when(requestOptionsMock.getWaitForResponses()).thenReturn(0);
+
+        this.msbContext = TestUtils.createMsbContextBuilder()
+                .withMsbConfigurations(msbConfigurationsMock)
+                .withMessageFactory(messageFactoryMock)
+                .withChannelManager(channelManagerMock)
+                .withClock(Clock.systemDefaultZone())
+                .withTimeoutManager(new TimeoutManager(1))
+                .withCollectorManagerFactory(collectorManagerFactoryMock)
+                .build();
+
+        Callback<Void> onEnd = mock(Callback.class);
+        when(eventHandlers.onEnd()).thenReturn(onEnd);
+
+        Collector<RestPayload> collector = createCollector();
+        collector.listenForResponses();
+
+        Acknowledge ack = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(3).withTimeoutMs(timeoutMsInAck)
+                .build();
+        Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
+        notifyMessagesConsumed(collector, 1);
+        collector.handleMessage(responseMessageWithAck, null);
+
+        //simulate responder response
+        Acknowledge responseAck = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(-1).build();
+        ObjectMapper payloadMapper = TestUtils.createMessageMapper();
+        JsonNode payloadNode = payloadMapper.readValue(String.format("{\"body\": \"%s\" }", "test response payload body"), JsonNode.class);
+
+        Message responderMessage = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE, "someCorrelationId");
+        notifyMessagesConsumed(collector, 1);
+        notifyMessagesLost(collector, 1);
+        verify(onEnd, never()).call(any());
+
+        //send message
+        notifyMessagesConsumed(collector, 1);
+        collector.handleMessage(responderMessage, null);
+
+        verify(onEnd, after(1500).times(1)).call(any());
     }
 
     @Test
@@ -648,6 +949,7 @@ public class CollectorTest {
         Acknowledge ack = new Acknowledge.Builder().withResponderId(responderId).withResponsesRemaining(2).withTimeoutMs(timeoutMsInAck)
                 .build();
         Message responseMessageWithAck = TestUtils.createMsbResponseMessageWithAckNoPayload(ack, TOPIC_RESPONSE, originalMessage.getCorrelationId());
+        notifyMessagesConsumed(collector, 1);
         collector.handleMessage(responseMessageWithAck, null);
 
         //simulate responder response
@@ -655,14 +957,17 @@ public class CollectorTest {
         ObjectMapper payloadMapper = TestUtils.createMessageMapper();
         JsonNode payloadNode = payloadMapper.readValue(String.format("{\"body\": \"%s\" }", "test response payload body"), JsonNode.class);
 
-        Message responderMessage = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE,  "someCorrelationId");
+        Message responderMessage1 = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE,  "someCorrelationId");
+        Message responderMessage2 = TestUtils.createMsbResponseMessage(responseAck, payloadNode, TOPIC_RESPONSE,  "someCorrelationId");
+
+        notifyMessagesConsumed(collector, 2);
 
         //send first message
-        collector.handleMessage(responderMessage, null);
+        collector.handleMessage(responderMessage1, null);
 
         //send second message after initial response
         Thread.sleep(200);
-        collector.handleMessage(responderMessage, null);
+        collector.handleMessage(responderMessage2, null);
 
         verify(onEnd, timeout(1500)).call(any());
     }
@@ -806,6 +1111,18 @@ public class CollectorTest {
             }
            
         };
+    }
+
+    private void notifyMessagesConsumed(Collector collector, int messagesCount) {
+        for(int i = 0; i < messagesCount; i++) {
+            ((ConsumedMessagesAwareMessageHandler)collector).notifyMessageConsumed();
+        }
+    }
+
+    private void notifyMessagesLost(Collector collector, int messagesCount) {
+        for(int i = 0; i < messagesCount; i++) {
+            ((ConsumedMessagesAwareMessageHandler)collector).notifyConsumedMessageIsLost();
+        }
     }
     
 


### PR DESCRIPTION
-fix "onEnd" callback invocation before all response callbacks were invoked;
-handle redelivered response messages so they are not handled as separate responses;
-catch and "onEnd"/"onResponse" callbacks exceptions so they are not propagated leading to "autoRetry"
