### PR TITLE
Update env variables doc, default values and naming

### DIFF
--- a/amqp/src/main/resources/amqp.conf
+++ b/amqp/src/main/resources/amqp.conf
@@ -7,9 +7,12 @@ config.amqp = {
   host = ${?MSB_BROKER_HOST}
   port = "5672"
   port = ${?MSB_BROKER_PORT}
+  username = "guest"
   username = ${?MSB_BROKER_USER_NAME}
+  password = "guest"
   password = ${?MSB_BROKER_PASSWORD}
-  virtualHost = ${?MSB_BROKER_VIRTUAL_HOST}
+  virtualHost = "/"
+  virtualHost = ${?MSB_BROKER_AMQP_VHOST}
   useSSL = false # true / false
   useSSL = ${?MSB_BROKER_USE_SSL}
 

--- a/doc/MSB.md
+++ b/doc/MSB.md
@@ -320,6 +320,17 @@ Here, the override field `name = ${?MSB_SERVICE_NAME}` simply vanishes if there'
 
 `brokerAdapterFactory` – message broker class. Defaults to `"io.github.tcdl.adapters.amqp.AmqpAdapterFactory"`.
 
+### Environment Variables
+
+- MSB_SERVICE_NAME
+- MSB_SERVICE_VERSION
+- MSB_SERVICE_INSTANCE_ID
+- MSB_BROKER_HOST, default "127.0.0.1".
+- MSB_BROKER_PORT, default 5672.
+- MSB_BROKER_USER_NAME, default "guest".
+- MSB_BROKER_PASSWORD, default "guest".
+- MSB_BROKER_VIRTUAL_HOST, default "/".
+
 ### Mapped Diagnostic Context settings
 This section provides settings for Mapped Diagnostic Context logging that gives a possibility to save some parameters of the incoming messages into a thread-local storage so it would be easier to track message processing.
 The section `mdcLogging`:


### PR DESCRIPTION
@bcolyn asked to rename env variables in Node.js and Java libs 
`MSB_AMQP_VHOST && MSB_BROKER_VIRTUAL_HOST => MSB_BROKER_AMQP_VHOST`. So this pull request implement this issue.