### PR TITLE
Disable MSB-Java using property

### DIFF
--- a/doc/MSB.md
+++ b/doc/MSB.md
@@ -285,6 +285,10 @@ All configuration files use _key-value pair_ structure.
 - [application.conf](/acceptance/src/main/resources/application.conf) - overrides values from reference.conf
 
 ### Description of MSB configuration fields
+
+There is a feature flag for enable/disable MSB:
+- `msb-config.enabled` true or missing value means enabled. false for disable whole MSB. It's very useful for testing and for enable/disable the msb capabilities depending of environments (f.e. as feature flag if the functionality is not desirable and/or not tested yet).
+
 Service details section describes microservice parameters.
 
 - `name ` – microservice name. All running instances of the same microservice must have the same name. Mandatory, has no default value.

--- a/spring-boot-starter/src/main/java/io/github/tcdl/msb/autoconfigure/MsbConfigAutoConfiguration.java
+++ b/spring-boot-starter/src/main/java/io/github/tcdl/msb/autoconfigure/MsbConfigAutoConfiguration.java
@@ -8,10 +8,12 @@ import io.github.tcdl.msb.support.Utils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@ConditionalOnProperty(name = "msb-config.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
 @AutoConfigureBefore(MsbContextAutoConfiguration.class)
 @EnableConfigurationProperties(MsbProperties.class)
@@ -20,9 +22,8 @@ public class MsbConfigAutoConfiguration {
     public static final String DEFAULT_VERSION = "1.0.0";
     public static final String DEFAULT_APP_NAME = Utils.generateId();
     public static final String DEFAULT_ADAPTER_FACTORY = "io.github.tcdl.msb.adapters.amqp.AmqpAdapterFactory";
-    private static final boolean DEFAULT_BROKER_DURABLE = true;
     public static final int DEFAULT_TIMER_THREAD_POOL_SIZE = 2;
-
+    private static final boolean DEFAULT_BROKER_DURABLE = true;
     @Autowired
     MsbProperties msbProperties;
 

--- a/spring-boot-starter/src/main/java/io/github/tcdl/msb/autoconfigure/MsbContextAutoConfiguration.java
+++ b/spring-boot-starter/src/main/java/io/github/tcdl/msb/autoconfigure/MsbContextAutoConfiguration.java
@@ -7,9 +7,11 @@ import io.github.tcdl.msb.config.MsbConfig;
 import io.github.tcdl.msb.threading.MessageGroupStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@ConditionalOnProperty(name = "msb-config.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
 public class MsbContextAutoConfiguration {
 

--- a/spring-boot-starter/src/test/java/io/github/tcdl/msb/autoconfigure/MsbAutoConfigurationDisableTest.java
+++ b/spring-boot-starter/src/test/java/io/github/tcdl/msb/autoconfigure/MsbAutoConfigurationDisableTest.java
@@ -1,0 +1,27 @@
+package io.github.tcdl.msb.autoconfigure;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {MsbConfigAutoConfiguration.class, MsbContextAutoConfiguration.class})
+@TestPropertySource(properties = "msb-config.enabled=false")
+public class MsbAutoConfigurationDisableTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void shouldDisableAutoConfigurationByFeatureFlag() {
+        assertTrue(context.getBeansOfType(MsbConfigAutoConfiguration.class).isEmpty());
+        assertTrue(context.getBeansOfType(MsbContextAutoConfiguration.class).isEmpty());
+    }
+
+}


### PR DESCRIPTION
Disable MSB-Java using property

- true or not present means enable (back compatibility)
- explicit false means disable
- Updated documentation
- Added test