### PR TITLE
IN-5774 Auto-retry after all errors if auto-acknowledgement is enabled

### DIFF
--- a/core/src/main/java/io/github/tcdl/msb/threading/MessageProcessingTask.java
+++ b/core/src/main/java/io/github/tcdl/msb/threading/MessageProcessingTask.java
@@ -45,12 +45,9 @@ public class MessageProcessingTask implements Runnable {
             messageHandler.handleMessage(message, ackHandler);
             LOG.debug("[correlation id: {}] Message has been processed", message.getCorrelationId());
             ackHandler.autoConfirm();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOG.error("[correlation id: {}] Failed to process message", message.getCorrelationId(), e);
             ackHandler.autoRetry();
-        } catch (Error error) {
-            LOG.error("[correlation id: {}] Failed to process message", message.getCorrelationId(), error);
-            throw error;
         } finally {
             if(mdcLogCopy) {
                 MDC.clear();


### PR DESCRIPTION
> In exceptional cases when the microservice is unable to handle messages successfully, reject or retry acknowledgment need be to send. If microservice doesn't explicitly send acknowledgment, MSB-Java can do it automatically after completion of message processing in current thread.

https://github.com/tcdl/msb-java/blob/master/doc/MSB.md